### PR TITLE
Update Heroku generator to enable force_ssl option in production

### DIFF
--- a/lib/generators/rolemodel/heroku/heroku_generator.rb
+++ b/lib/generators/rolemodel/heroku/heroku_generator.rb
@@ -10,5 +10,9 @@ module Rolemodel
     def install_procfile
       template 'Procfile'
     end
+
+    def force_ssl
+      uncomment_lines('config/environments/production.rb', 'config.force_ssl = true')
+    end
   end
 end


### PR DESCRIPTION
Every app should be using SSL in production, especially on Heroku.

This generator change relies on Rails' default version of `config/environments/production.rb`, and assumes `force_ssl` is already set to `true` when the no commented-out `config.force_ssl = true` line exists. If that assumption isn't safe to make, I can make this more robust.