### PR TITLE
Fix typo in ESLint generator

### DIFF
--- a/lib/generators/rolemodel/linters/eslint/eslint_generator.rb
+++ b/lib/generators/rolemodel/linters/eslint/eslint_generator.rb
@@ -12,7 +12,7 @@ module Rolemodel
           babel-eslint
           eslint-config-airbnb
           eslint-plugin-import
-          esling-import-resolver-webpack
+          eslint-import-resolver-webpack
           eslint-plugin-jsx-a11y
           eslint-plugin-react
           eslint-plugin-react-hooks


### PR DESCRIPTION
This typo broke any ESLint rules related to resolving imports, since the required webpack resolver plugin didn't get installed.