### PR TITLE
Update heroku postdeploy command to fix an error on heroku

### DIFF
--- a/lib/generators/rolemodel/heroku/templates/app.json.erb
+++ b/lib/generators/rolemodel/heroku/templates/app.json.erb
@@ -1,7 +1,7 @@
 {
   "name": "<%= @project_name %>",
   "scripts": {
-    "postdeploy": "bin/rails db:schema:load db:seed"
+    "postdeploy": "bin/rails db:seed"
   },
   "env": {
     "HONEYBADGER_API_KEY": {


### PR DESCRIPTION
This fixes an issue with heroku postdeploy command failing with 'potentially destructive action' error.