### PR TITLE
Add icons generator

### DIFF
--- a/lib/generators/rolemodel/css/README.md
+++ b/lib/generators/rolemodel/css/README.md
@@ -4,7 +4,8 @@
 
 ## Sub Generators
 
-* [Base CSS](base)
+* [Base CSS](./base)
+* [Icons](./icons)
 
 ## Future Generators
 

--- a/lib/generators/rolemodel/css/all_generator.rb
+++ b/lib/generators/rolemodel/css/all_generator.rb
@@ -4,10 +4,8 @@ module Rolemodel
       source_root File.expand_path('templates', __dir__)
 
       def run_all_the_generators
-        Dir.glob(Pathname(File.expand_path('.', __dir__)).join('*', '*generator.rb')).each do |generator|
-          name = File.basename(generator, '_generator.rb')
-          generate "rolemodel:css:#{name}"
-        end
+        generate 'rolemodel:css:base'
+        generate 'rolemodel:css:icons'
       end
     end
   end

--- a/lib/generators/rolemodel/css/icons/README.md
+++ b/lib/generators/rolemodel/css/icons/README.md
@@ -1,0 +1,8 @@
+# Icons Generator
+
+Depends on [Base CSS Generator](../base)
+
+## What you get
+
+* material-icons and the necessary CSS setup
+* A view helper for icons (`icon(name)`)

--- a/lib/generators/rolemodel/css/icons/USAGE
+++ b/lib/generators/rolemodel/css/icons/USAGE
@@ -1,0 +1,12 @@
+Description:
+    runs the icons css generator
+
+Example:
+    rails generate rolemodel:css:icons
+
+    This will create:
+        app/helpers/icon_helper.rb
+        app/javascript/stylesheets/components/icon.scss
+
+    This will modify:
+        app/javascript/packs/stylesheets.scss

--- a/lib/generators/rolemodel/css/icons/icons_generator.rb
+++ b/lib/generators/rolemodel/css/icons/icons_generator.rb
@@ -1,0 +1,20 @@
+module Rolemodel
+  module Css
+    class IconsGenerator < Rails::Generators::Base
+      source_root File.expand_path('templates', __dir__)
+
+      def add_material_icons
+        run 'yarn add material-icons'
+      end
+
+      def add_view_helper
+        template 'app/helpers/icon_helper.rb'
+      end
+
+      def add_css
+        template 'app/javascript/stylesheets/components/icon.scss'
+        append_file 'app/javascript/packs/stylesheets.scss', "@import 'stylesheets/components/icon';"
+      end
+    end
+  end
+end

--- a/lib/generators/rolemodel/css/icons/icons_generator.rb
+++ b/lib/generators/rolemodel/css/icons/icons_generator.rb
@@ -8,11 +8,11 @@ module Rolemodel
       end
 
       def add_view_helper
-        template 'app/helpers/icon_helper.rb'
+        copy_file 'app/helpers/icon_helper.rb'
       end
 
       def add_css
-        template 'app/javascript/stylesheets/components/icon.scss'
+        copy_file 'app/javascript/stylesheets/components/icon.scss'
         append_file 'app/javascript/packs/stylesheets.scss', "@import 'stylesheets/components/icon';"
       end
     end

--- a/lib/generators/rolemodel/css/icons/templates/app/helpers/icon_helper.rb
+++ b/lib/generators/rolemodel/css/icons/templates/app/helpers/icon_helper.rb
@@ -1,0 +1,5 @@
+module IconHelper
+  def icon(name, classes: nil, color: nil, hover_text: nil)
+    tag.span(name, class: "material-icons #{classes}", style: "color: var(--color-#{color})", title: hover_text)
+  end
+end

--- a/lib/generators/rolemodel/css/icons/templates/app/javascript/stylesheets/components/icon.scss
+++ b/lib/generators/rolemodel/css/icons/templates/app/javascript/stylesheets/components/icon.scss
@@ -1,0 +1,13 @@
+// Look up icons at: https://material.io/resources/icons/
+$material-icons-font-path: '~material-icons/iconfont/';
+@import '~material-icons/iconfont/material-icons.scss';
+.material-icons {
+  font-size: 1.3em;
+  line-height: 0.9em;
+
+  max-width: 28px;
+}
+
+.material-icons--lg {
+  font-size: 5rem;
+}


### PR DESCRIPTION
Adds a generator for a basic icon setup using material-icons. This doesn't support custom icons, but that could be added in a future PR (or possibly in this PR).

Most implementations of this pattern have put the `icon` helper method in `ApplicationHelper`. I opted to move this to its own helper file to reduce generator complexity and potential conflicts (I've tried this in an app and Rails does pick up the helper file).