### PR TITLE
Fix icons generator when running all generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ bin/rails g
 * [Webpacker](./lib/generators/rolemodel/webpacker)
 * [CSS](./lib/generators/rolemodel/css)
   * [Base](./lib/generators/rolemodel/css/base)
+  * [Icons](./lib/generators/rolemodel/css/icons)
 * [Readme](./lib/generators/rolemodel/readme)
 * [Heroku](./lib/generators/rolemodel/heroku)
 * [SoftDestroyable](./lib/generators/rolemodel/soft_destroyable)

--- a/lib/generators/rolemodel/all_generator.rb
+++ b/lib/generators/rolemodel/all_generator.rb
@@ -3,11 +3,11 @@ module Rolemodel
     source_root File.expand_path('templates', __dir__)
 
     def run_all_the_generators
-      generate 'rolemodel:css:all'
       generate 'rolemodel:github'
       generate 'rolemodel:heroku'
       generate 'rolemodel:readme'
       generate 'rolemodel:webpacker'
+      generate 'rolemodel:css:all'
       generate 'rolemodel:testing:all'
       generate 'rolemodel:soft_destroyable'
       generate 'rolemodel:saas:all'


### PR DESCRIPTION
The `css:icons` generator needs to run after `webpacker`. Otherwise, its changes to `package.json` to install `material-icons` get overwritten. A reference to the icons generator was also missing from the top-level readme.