### PR TITLE
Configure Capybara to support data-testid attributes

### DIFF
--- a/lib/generators/rolemodel/testing/rspec/USAGE
+++ b/lib/generators/rolemodel/testing/rspec/USAGE
@@ -8,5 +8,6 @@ Example:
         spec/rails_helper.rb
         spec/spec_helper.rb
         spec/support/capybara_drivers.rb
+        spec/support/capybara_testid.rb
         spec/support/helpers.rb
         .rspec

--- a/lib/generators/rolemodel/testing/rspec/rspec_generator.rb
+++ b/lib/generators/rolemodel/testing/rspec/rspec_generator.rb
@@ -24,6 +24,7 @@ module Rolemodel
         template 'spec_helper.rb', 'spec/spec_helper.rb'
         template '.rspec', '.rspec'
         template 'support/capybara_drivers.rb', 'spec/support/capybara_drivers.rb'
+        template 'support/capybara_testid.rb', 'spec/support/capybara_testid.rb'
         template 'support/helpers.rb', 'spec/support/helpers.rb'
         append_file '.gitignore', 'spec/examples.txt'
       end

--- a/lib/generators/rolemodel/testing/rspec/templates/support/capybara_testid.rb
+++ b/lib/generators/rolemodel/testing/rspec/templates/support/capybara_testid.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Capybara.configure do |config|
+  config.test_id = 'data-testid'
+end


### PR DESCRIPTION
This adds configuration for Capybara to support the `data-testid` attribute like `react-testing-library` does. The naming for the attribute matches `react-testing-library`'s default.