### PR TITLE
Turbo setup

### DIFF
--- a/example_rails6/Gemfile.lock
+++ b/example_rails6/Gemfile.lock
@@ -102,7 +102,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     minitest (5.14.4)
     msgpack (1.4.2)
@@ -193,6 +195,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/lib/generators/rolemodel/README.md
+++ b/lib/generators/rolemodel/README.md
@@ -12,6 +12,7 @@
 * [SoftDestroyable](./soft_destroyable)
 * [Testing](./testing)
 * [Webpacker](./webpacker)
+* [Turbo](./turbo)
 * [README](./readme)
 
 ## Helpful documentation

--- a/lib/generators/rolemodel/all_generator.rb
+++ b/lib/generators/rolemodel/all_generator.rb
@@ -7,6 +7,7 @@ module Rolemodel
       generate 'rolemodel:heroku'
       generate 'rolemodel:readme'
       generate 'rolemodel:webpacker'
+      generate 'rolemodel:turbo'
       generate 'rolemodel:css:all'
       generate 'rolemodel:testing:all'
       generate 'rolemodel:simple_form'

--- a/lib/generators/rolemodel/modals/USAGE
+++ b/lib/generators/rolemodel/modals/USAGE
@@ -8,4 +8,5 @@ Example:
         css
         helpers
         javascript
+        turbo config
         views

--- a/lib/generators/rolemodel/modals/modals_generator.rb
+++ b/lib/generators/rolemodel/modals/modals_generator.rb
@@ -5,6 +5,7 @@ module Rolemodel
     def install_icons
       generate 'rolemodel:css:base' unless File.exists?(Rails.root.join('app/javascript/packs/stylesheets.scss'))
       generate 'rolemodel:css:icons'
+      generate 'rolemodel:turbo'
     end
 
     def add_ui_components

--- a/lib/generators/rolemodel/modals/templates/application_addendum.js
+++ b/lib/generators/rolemodel/modals/templates/application_addendum.js
@@ -2,7 +2,7 @@ import RolemodelPanel from 'helpers/rolemodel-panel'
 import RolemodelModal from 'helpers/rolemodel-modal'
 import RolemodelConfirm from 'helpers/rolemodel-confirm'
 
-document.addEventListener('turbolinks:load', () => {
+document.addEventListener('turbo:load', () => {
   RolemodelPanel.init()
   RolemodelModal.init()
   RolemodelConfirm.init()

--- a/lib/generators/rolemodel/turbo/README.md
+++ b/lib/generators/rolemodel/turbo/README.md
@@ -1,0 +1,17 @@
+# Turbo Generator
+
+## What you get
+
+A Turbo installation with a standard config.
+
+## Why do we use Turbo?
+
+[Turbo](https://turbo.hotwired.dev/)
+
+Turbo uses complementary techniques to dramatically reduce the amount of custom JavaScript that most web applications will need to write:
+
+It's all done by sending HTML over the wire. And for those instances when that's not enough, you can reach for the other side of Hotwire, and finish the job with Stimulus.
+
+* Turbo Drive accelerates links and form submissions by negating the need for full page reloads.
+* Turbo Frames decompose pages into independent contexts, which scope navigation and can be lazily loaded.
+* Turbo Streams deliver page changes over WebSocket, SSE or in response to form submissions using just HTML and a set of CRUD-like actions.

--- a/lib/generators/rolemodel/turbo/USAGE
+++ b/lib/generators/rolemodel/turbo/USAGE
@@ -1,0 +1,5 @@
+Description:
+    Sets up our standard Turbo configuration
+
+Example:
+    rails generate rolemodel:turbo

--- a/lib/generators/rolemodel/turbo/templates/application_addendum.js
+++ b/lib/generators/rolemodel/turbo/templates/application_addendum.js
@@ -1,0 +1,4 @@
+// Temp fix for turbo and react. Should be update in later version of react-rails
+// See https://github.com/reactjs/react-rails/issues/1103 for details
+ReactRailsUJS.handleEvent('turbo:load', ReactRailsUJS.handleMount);
+ReactRailsUJS.handleEvent('turbo:before-render', ReactRailsUJS.handleUnmount);

--- a/lib/generators/rolemodel/turbo/turbo_generator.rb
+++ b/lib/generators/rolemodel/turbo/turbo_generator.rb
@@ -1,4 +1,4 @@
-require_relative '../../../bundler_helpers'
+require_relative '../../bundler_helpers'
 
 module Rolemodel
   class TurboGenerator < Rails::Generators::Base
@@ -6,10 +6,10 @@ module Rolemodel
     source_root File.expand_path('templates', __dir__)
 
     def install_turbo
-      gem 'turbo'
+      gem 'turbo-rails'
       run_bundle
 
-      generate 'turbo:install'
+      run 'rails turbo:install'
     end
   end
 end

--- a/lib/generators/rolemodel/turbo/turbo_generator.rb
+++ b/lib/generators/rolemodel/turbo/turbo_generator.rb
@@ -1,0 +1,15 @@
+require_relative '../../../bundler_helpers'
+
+module Rolemodel
+  class TurboGenerator < Rails::Generators::Base
+    include Rolemodel::BundlerHelpers
+    source_root File.expand_path('templates', __dir__)
+
+    def install_turbo
+      gem 'turbo'
+      run_bundle
+
+      generate 'turbo:install'
+    end
+  end
+end

--- a/lib/generators/rolemodel/turbo/turbo_generator.rb
+++ b/lib/generators/rolemodel/turbo/turbo_generator.rb
@@ -11,5 +11,10 @@ module Rolemodel
 
       run 'rails turbo:install'
     end
+
+    def add_react_rails_ujs_event_handlers
+      addendum = File.read([source_paths.last, '/application_addendum.js'].join)
+      append_to_file 'app/javascript/packs/application.js', addendum
+    end
   end
 end


### PR DESCRIPTION
## Why?

Since we are starting to adopt Turbo usage more often, we want to simplify the setup and add fixes and other changes we have found to be helpful.

## What Changed

* [X] Update example_rails6 mimemagic gem version
* [X] Add Turbo Generator to replace turbolinks
* [X] Update Modals generator to require turbo first
* [X] Change Modals generator event listener to listen for `turbo:load` instead of `turbolinks:load`
* [X] Update All generator to run turbo generator