### PR TITLE
Fix "Fixed width flex items" overlapping container when combined with gap

### DIFF
--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/utilities.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/utilities.scss
@@ -54,10 +54,19 @@
   & > * {
     flex: 1;
 
-    &.four-fifths-width, &.three-fifths-width, &.two-fifths-width, &.one-fifth-width,
-    &.three-quarters-width, &.one-quarter-width,
-    &.two-thirds-width, &.one-third-width,
-    &.full-width, &.half-width { flex: none; }
+    &.four-fifths-width { flex-basis: calc(100% * 4/5); }
+    &.three-fifths-width { flex-basis: calc(100% * 3/5); }
+    &.two-fifths-width { flex-basis: calc(100% * 2/5); }
+    &.one-fifth-width { flex-basis: calc(100% * 1/5); }
+
+    &.three-quarters-width { flex-basis: calc(100% * 3/4); }
+    &.one-quarter-width { flex-basis: calc(100% * 1/4); }
+
+    &.two-thirds-width { flex-basis: calc(100% * 2/3); }
+    &.one-third-width { flex-basis: calc(100% * 1/3); }
+
+    &.full-width { flex-basis: 100%; }
+    &.half-width { flex-basis: 50%; }
   }
 
   @media screen and (max-width: $breakpoint-sm) {


### PR DESCRIPTION
## Why?

If you set a fixed width on all items of a flex container that is using layout-row and gap, they overlap the container due to the gap adding space.

## What Changed

* [X] Change layout-row to apply flex-basis for the width utilities so it still obeys the flex container.

## Screenshots

Old:
<img width="1200" alt="Screen Shot 2021-11-20 at 11 03 54 PM" src="https://user-images.githubusercontent.com/5957102/142749234-b2014163-2487-4956-aa1b-2bffcb831c3e.png">

New:
<img width="1202" alt="Screen Shot 2021-11-20 at 11 01 02 PM" src="https://user-images.githubusercontent.com/5957102/142749239-8bd6fb27-b0e8-4b35-8cf6-ce2bca415e2b.png">