### PR TITLE
[TR #76] add-neutral-semantic-scales

### DIFF
--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/semantic_backgrounds.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/semantic_backgrounds.scss
@@ -1,5 +1,5 @@
 // Semantic backgrounds
-$semantic_backgrounds_scales: 'primary', 'secondary', 'tertiary';
+$semantic_backgrounds_scales: 'primary', 'secondary', 'tertiary', 'neutral', 'neutral-variant';
 @each $color in $semantic_backgrounds_scales {
   .background-#{$color}-base {
     background-color: var(--color-#{$color}-base);

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/dark_mode.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/dark_mode.scss
@@ -21,7 +21,7 @@
         --color-#{$color}-100: hsl(var(--color-#{$color}-h), var(--color-#{$color}-s), 100%);
       }
 
-      $semantic_color_scales: 'primary', 'secondary', 'tertiary';
+      $semantic_color_scales: 'primary', 'secondary', 'tertiary', 'neutral', 'neutral-variant';
       @each $color in $semantic_color_scales {
         --color-#{$color}-lightest: var(--color-#{$color}-20);
         --color-#{$color}-lighter:  var(--color-#{$color}-30);
@@ -51,7 +51,7 @@
       // Neutral Variant Colors (normal usage)
       --color-surface-variant:    var(--color-neutral-variant-30);
       --color-on-surface-variant: var(--color-neutral-variant-80);
-      --color-outline:            var(--color-neutral-variant-60);
+      --color-outline:            var(--color-neutral-variant-40);
     }
 
     .modal__content {

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/semantic_color_scales.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/semantic_color_scales.scss
@@ -5,7 +5,7 @@
   --color-neutral: hsl(var(--color-neutral-h), var(--color-neutral-s), var(--color-neutral-l));
   --color-neutral-variant: hsl(var(--color-neutral-variant-h), var(--color-neutral-variant-s), var(--color-neutral-variant-l));
 
-  $semantic_color_scales: 'primary', 'secondary', 'tertiary';
+  $semantic_color_scales: 'primary', 'secondary', 'tertiary', 'neutral', 'neutral-variant';
   @each $color in $semantic_color_scales {
     --color-#{$color}-lightest: var(--color-#{$color}-95);
     --color-#{$color}-lighter:  var(--color-#{$color}-80);
@@ -35,7 +35,7 @@
   // Neutral Variant Colors (normal usage)
   --color-surface-variant:    var(--color-neutral-variant-90);
   --color-on-surface-variant: var(--color-neutral-variant-30);
-  --color-outline:            var(--color-neutral-variant-50);
+  --color-outline:            var(--color-neutral-variant-80);
 
   // Alert Colors
   $alert_color_scales: ('warning': 'yellow', 'danger': 'red', 'info': 'blue', 'notice': 'green');

--- a/lib/generators/rolemodel/css/base/templates/app/views/styleguide/index.html.slim
+++ b/lib/generators/rolemodel/css/base/templates/app/views/styleguide/index.html.slim
@@ -88,18 +88,18 @@
 
       .margin-top-md
         h4 Neutral
-        .flex.layout-row.gap-md.flex-wrap
-          .swatch.elevation-1 style="background: var(--color-background); color: var(--color-on-background)" Background (50)
-          .swatch.elevation-1 style="background: var(--color-on-background); color: var(--color-background)" On Background (900)
-          .swatch.elevation-1 style="background: var(--color-surface); color: var(--color-on-surface)" Surface (50)
-          .swatch.elevation-1 style="background: var(--color-on-surface); color: var(--color-surface)" On Surface (900)
+        = render 'shared/semantic_color_scale', scale_name: 'neutral'
 
       .margin-top-md
-        h4 Neutral Variant
+        h4 Neutral-Variant
+        = render 'shared/semantic_color_scale', scale_name: 'neutral-variant'
+
+      .margin-top-md
+        h4 Miscellaneous
         .flex.layout-row.gap-md.flex-wrap
-          .swatch.elevation-1 style="background: var(--color-surface-variant); color: var(--color-on-surface-variant)" Surface Variant (50)
-          .swatch.elevation-1 style="background: var(--color-on-surface-variant); color: var(--color-surface-variant)" On Surface Variant (900)
-          .swatch.elevation-1 style="background: var(--color-outline); color: var(--color-surface)" Outline (300)
+          .swatch.elevation-1 style="background: var(--color-background); color: var(--color-on-background)" Background (Neutral 98)
+          .swatch.elevation-1 style="background: var(--color-on-background); color: var(--color-background)" On Background (Neutral 10)
+          .swatch.elevation-1 style="background: var(--color-outline); color: var(--color-background)" Outline (Neutral Variant 80)
 
   section.card.card--rounded.card--outlined.margin-top-md
     .card__header.background-primary-lightest


### PR DESCRIPTION
## Task

[TR #76](https://trello.com/c/fRWGaCc9/76-e48-neutral-semantic-scales)

## Why?

Added neutral semantic scales for greater flexibility with styling.
