### PR TITLE
[TR #77] convert-surface-colors-to-background-colors

### DIFF
--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/button.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/button.scss
@@ -76,8 +76,8 @@ button {
   color: var(--color-on-background);
 
   &:hover {
-    background: var(--color-surface-variant);
-    color: var(--color-on-surface-variant);
+    background: var(--color-neutral-variant-lightest);
+    color: var(--color-on-neutral-variant-lightest);
   }
 
   &.btn--primary {

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/button.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/button.scss
@@ -72,8 +72,8 @@ button {
 
 .btn--outline {
   border: var(--border-width) solid var(--color-outline);
-  background: var(--color-surface);
-  color: var(--color-on-surface);
+  background: var(--color-background);
+  color: var(--color-on-background);
 
   &:hover {
     background: var(--color-surface-variant);

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/card.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/card.scss
@@ -1,6 +1,6 @@
 .card {
-  background: var(--color-surface);
-  color: var(--color-on-surface);
+  background: var(--color-background);
+  color: var(--color-on-background);
 
   border-radius: var(--radius);
 

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/form.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/form.scss
@@ -16,7 +16,7 @@ label {
   padding-bottom: var(--space-xs);
   margin-bottom: 0;
   line-height: 1.5;
-  color: var(--color-on-surface);
+  color: var(--color-on-background);
   font-weight: 400;
   font-size: var(--text-sm);
   letter-spacing: 0.4px;
@@ -29,8 +29,8 @@ label {
   padding: var(--space-sm) var(--space-md);
   font-size: var(--text-sm);
   line-height: 1.5;
-  background-color: var(--color-surface);
-  color: var(--color-on-surface);
+  background-color: var(--color-background);
+  color: var(--color-on-background);
   border: var(--border-width) solid var(--color-outline);
   font-weight: 300;
   will-change: border-color, box-shadow;
@@ -40,7 +40,7 @@ label {
   &:focus {
     color: var(--color-black);
     outline: 0;
-    border-color: var(--color-on-surface);
+    border-color: var(--color-on-background);
   }
 }
 
@@ -51,8 +51,8 @@ label {
   outline: 0;
   background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgaGVpZ2h0PSIxNCIgdmlld0JveD0iMCAwIDI5IDE0IiB3aWR0aD0iMjkiPjxwYXRoIGZpbGw9IiNkMWQxZDEiIGQ9Ik05LjM3NzI3IDMuNjI1bDUuMDgxNTQgNi45MzUyM0wxOS41NDAzNiAzLjYyNSIvPjwvc3ZnPgo=') center right no-repeat;
   background-size: 30px 15px;
-  background-color: var(--color-surface);
-  color: var(--color-on-surface);
+  background-color: var(--color-background);
+  color: var(--color-on-background);
   border: var(--border-width) solid var(--color-outline);
   font-weight: 300;
   font-size: var(--text-sm);
@@ -64,11 +64,11 @@ label {
 
   &:hover:not(:focus):not(:disabled) {
     cursor: pointer;
-    border-color: var(--color-on-surface);
+    border-color: var(--color-on-background);
   }
 
   &:focus {
-    border-color: var(--color-on-surface);
+    border-color: var(--color-on-background);
     outline: 0;
   }
 }
@@ -86,7 +86,7 @@ label {
   label {
     // Label text
     position: relative;
-    color: var(--color-on-surface);
+    color: var(--color-on-background);
     font-weight: 500;
     cursor: pointer;
     display: inline;
@@ -114,8 +114,8 @@ label {
     &:before {
       width: 20px;
       height: 20px;
-      background: var(--color-surface);
-      color: var(--color-on-surface);
+      background: var(--color-background);
+      color: var(--color-on-background);
       border: var(--border-width) solid var(--color-outline);
       border-radius: var(--space-xxs);
       cursor: pointer;

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/form.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/form.scss
@@ -156,21 +156,21 @@ label {
         cursor: not-allowed;
 
         &:before{
-          border-color: var(--color-on-surface-variant);
-          background-color: var(--color-surface-variant);
+          border-color: var(color-on-neutral-variant-lightest);
+          background-color: var(color-neutral-variant-lightest);
           cursor: not-allowed;
         }
 
         &:after {
           // Checkmark
-          border-color: var(--color-on-surface-variant);
+          border-color: var(color-on-neutral-variant-lightest);
         }
       }
 
       &:checked {
         + label:before {
-          border-color: var(--color-on-surface-variant);
-          background-color: var(--color-surface-variant);
+          border-color: var(color-on-neutral-variant-lightest);
+          background-color: var(color-neutral-variant-lightest);
           cursor: not-allowed;
         }
       }
@@ -218,20 +218,20 @@ label {
 
   // Disabled
   &:disabled {
-    background-color: var(--color-surface-variant);
-    border-color: var(--color-on-surface-variant);
+    background-color: var(color-neutral-variant-lightest);
+    border-color: var(color-on-neutral-variant-lightest);
     cursor: not-allowed;
 
     &:after {
       // hide white circle
       opacity: 0;
-      color: var(--color-on-surface-variant);
-      background-color: var(--color-on-surface-variant);
+      color: var(color-on-neutral-variant-lightest);
+      background-color: var(color-on-neutral-variant-lightest);
     }
 
     &:checked {
-      background-color: var(--color-surface-variant);
-      border-color: var(--color-on-surface-variant);
+      background-color: var(color-neutral-variant-lightest);
+      border-color: var(color-on-neutral-variant-lightest);
 
       &:after {
         // show white circle

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/swatch.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/swatch.scss
@@ -5,8 +5,8 @@
   span {
     display: block;
     padding: var(--space-xxs) var(--space-xs);
-    background: var(--color-surface);
-    color: var(--color-on-surface);
+    background: var(--color-background);
+    color: var(--color-on-background);
 
     border: 1px solid var(--color-outline);
     border-radius: var(--radius);

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/table.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/table.scss
@@ -4,7 +4,7 @@ table.table {
   border-collapse: collapse;
 
   thead {
-    background: var(--color-surface);
+    background: var(--color-background);
   }
 
   th {
@@ -13,7 +13,7 @@ table.table {
     text-align: left;
     text-transform: uppercase;
 
-    color: var(--color-on-surface);
+    color: var(--color-on-background);
     border-bottom: var(--border-width) solid var(--color-outline);
 
     font-size: var(--text-sm);
@@ -31,7 +31,7 @@ table.table {
   td {
     padding: 0.75rem var(--space-md);
 
-    color: var(--color-on-surface);
+    color: var(--color-on-background);
     border-bottom: var(--border-width) solid var(--color-outline);
 
     font-size: 0.875rem;

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/dark_mode.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/dark_mode.scss
@@ -42,19 +42,15 @@
         --color-on-#{$color}-darkest:  var(--color-#{$color}-10);
       }
 
-      // Neutral Colors (normal usage)
+      // Miscellaneous Colors
       --color-background:    var(--color-neutral-10);
       --color-on-background: var(--color-neutral-90);
-
-      // Neutral Variant Colors (normal usage)
-      --color-surface-variant:    var(--color-neutral-variant-30);
-      --color-on-surface-variant: var(--color-neutral-variant-80);
-      --color-outline:            var(--color-neutral-variant-40);
+      --color-outline:       var(--color-neutral-variant-40);
     }
 
     .modal__content {
-      background: var(--color-surface-variant);
-      color: var(--color-on-surface-variant);
+      background: var(color-neutral-variant-lightest);
+      color: var(color-on-neutral-variant-lightest);
     }
 
     .modal__close {
@@ -64,8 +60,8 @@
     }
 
     .panel {
-      background: var(--color-surface-variant);
-      color: var(--color-on-surface-variant);
+      background: var(color-neutral-variant-lightest);
+      color: var(color-on-neutral-variant-lightest);
     }
 
     .panel__close {

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/dark_mode.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/dark_mode.scss
@@ -45,8 +45,6 @@
       // Neutral Colors (normal usage)
       --color-background:    var(--color-neutral-10);
       --color-on-background: var(--color-neutral-90);
-      --color-surface:       var(--color-neutral-10);
-      --color-on-surface:    var(--color-neutral-80);
 
       // Neutral Variant Colors (normal usage)
       --color-surface-variant:    var(--color-neutral-variant-30);
@@ -61,7 +59,7 @@
 
     .modal__close {
       &:hover {
-        background: var(--color-surface);
+        background: var(--color-background);
       }
     }
 
@@ -72,7 +70,7 @@
 
     .panel__close {
       &:hover {
-        background: var(--color-surface);
+        background: var(--color-background);
       }
     }
   }

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/semantic_color_scales.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/semantic_color_scales.scss
@@ -29,8 +29,6 @@
   // Neutral Colors (normal usage)
   --color-background:    var(--color-neutral-98);
   --color-on-background: var(--color-neutral-10);
-  --color-surface:       var(--color-neutral-98);
-  --color-on-surface:    var(--color-neutral-10);
 
   // Neutral Variant Colors (normal usage)
   --color-surface-variant:    var(--color-neutral-variant-90);

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/semantic_color_scales.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/semantic_color_scales.scss
@@ -26,14 +26,10 @@
     --color-on-#{$color}-darkest:  var(--color-#{$color}-100);
   }
 
-  // Neutral Colors (normal usage)
+  // Miscellaneous Colors
   --color-background:    var(--color-neutral-98);
   --color-on-background: var(--color-neutral-10);
-
-  // Neutral Variant Colors (normal usage)
-  --color-surface-variant:    var(--color-neutral-variant-90);
-  --color-on-surface-variant: var(--color-neutral-variant-30);
-  --color-outline:            var(--color-neutral-variant-80);
+  --color-outline:       var(--color-neutral-variant-80);
 
   // Alert Colors
   $alert_color_scales: ('warning': 'yellow', 'danger': 'red', 'info': 'blue', 'notice': 'green');

--- a/lib/generators/rolemodel/modals/templates/app/javascript/stylesheets/components/modal.scss
+++ b/lib/generators/rolemodel/modals/templates/app/javascript/stylesheets/components/modal.scss
@@ -75,6 +75,6 @@
   border-radius: var(--radius-max);
 
   &:hover {
-    background: var(--color-surface-variant);
+    background: var(color-neutral-variant-lightest);
   }
 }

--- a/lib/generators/rolemodel/modals/templates/app/javascript/stylesheets/components/modal.scss
+++ b/lib/generators/rolemodel/modals/templates/app/javascript/stylesheets/components/modal.scss
@@ -37,8 +37,8 @@
   max-height: 500px;
   width: var(--modal-width);
   padding: var(--space-lg);
-  background: var(--color-surface);
-  color: var(--color-on-surface);
+  background: var(--color-background);
+  color: var(--color-on-background);
 
   border-radius: var(--radius);
   z-index: 12;

--- a/lib/generators/rolemodel/modals/templates/app/javascript/stylesheets/components/panel.scss
+++ b/lib/generators/rolemodel/modals/templates/app/javascript/stylesheets/components/panel.scss
@@ -7,8 +7,8 @@
   z-index: 100;
   position: absolute;
   right: calc(-1 * var(--panel-width)); // this pushes the panel off the sceen to the right
-  background: var(--color-surface);
-  color: var(--color-on-surface);
+  background: var(--color-background);
+  color: var(--color-on-background);
   transition: right var(--panel-transition-speed);
 
   overflow-y: scroll;

--- a/lib/generators/rolemodel/modals/templates/app/javascript/stylesheets/components/panel.scss
+++ b/lib/generators/rolemodel/modals/templates/app/javascript/stylesheets/components/panel.scss
@@ -28,7 +28,7 @@
   border-radius: var(--radius-max);
 
   &:hover {
-    background: var(--color-surface-variant);
+    background: var(color-neutral-variant-lightest);
   }
 }
 


### PR DESCRIPTION
## Task

[TR #77](https://trello.com/c/Nnsc49kY/77-e48-convert-surface-colors-to-background-colors)

## Why?

Surface and background are synonymous and we don't need specific names for them when we can use semantic scales.

## What Changed

What changed in this PR?

* [x] Replaced surface with background
* [x] Replaced surface-variant with semantic neutral-variant

## Screenshots

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/88258994/149555461-67f2eb40-d253-4620-a9de-9fb732201214.png">

<img width="962" alt="image" src="https://user-images.githubusercontent.com/88258994/149555515-758c4c7f-606c-42c1-a3ec-65eb62b45791.png">

