### PR TITLE
[TR #66] restructure-card-file

### DIFF
--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/card.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/card.scss
@@ -22,9 +22,8 @@
 %card {
   position: relative;
   background-color: var(--color-white);
-  border: var(--border-width-sm) solid var(--color-neutral-light);
+  box-shadow: var(--border-card-outline);
   border-radius: var(--radius);
-  box-shadow: var(--shadow-neutral-elevation-md);
   color: var(--color-neutral-darker);
   font-size: var(--text-md);
   line-height: var(--line-height-base);

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/card.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/card.scss
@@ -1,30 +1,54 @@
-.card {
-  background: var(--color-background);
-  color: var(--color-on-background);
+// DOCS
 
+// -- For a card with header, body, and footer --
+
+// .card
+//   .card__header
+//     {{Content}}
+//   .card__body
+//     {{Content}}
+//   .card__footer
+//     {{Content}}
+
+// -- For a simple one-panel card with content --
+
+// .card--padded
+//   {{Content}}
+
+:root {
+  --card-padding: var(--space-md);
+}
+
+%card {
+  position: relative;
+  background-color: var(--color-white);
+  border: var(--border-width-sm) solid var(--color-neutral-light);
   border-radius: var(--radius);
-
+  box-shadow: var(--shadow-neutral-elevation-md);
+  color: var(--color-neutral-darker);
+  font-size: var(--text-md);
+  line-height: var(--line-height-base);
   overflow: hidden;
 }
 
-.card__header, .card__body, .card__footer {
-  padding: var(--space-md);
+.card {
+  @extend %card;
+}
+
+.card--padded {
+  @extend %card;
+
+  padding: var(--card-padding);
+}
+
+.card__header,
+.card__body,
+.card__footer {
+  padding: var(--card-padding);
 }
 
 .card__header {
   h1, h2, h3, h4, h5, h6 {
-    margin: unset;
+    margin: 0;
   }
-}
-
-.card--padded {
-  padding: var(--space-md);
-}
-
-.card--rounded {
-  border-radius: var(--radius-lg);
-}
-
-.card--outlined {
-  border: 1px solid var(--color-outline);
 }

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/tokens.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/tokens.scss
@@ -16,6 +16,10 @@
   --border-width-sm: 1px;
 }
 
+@mixin border-strokes {
+  --border-card-outline: 0 0 0 1px var(--color-outline);
+}
+
 @mixin text-scales {
   // Visit https://codyhouse.co/ds/globals/typography to play around with different text sizes
   --text-base-size: 1rem;
@@ -68,6 +72,7 @@
 
 :root {
   // Border
+  @include border-strokes;
   @include border-radius;
   @include border-width;
 

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/tokens.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/tokens.scss
@@ -34,6 +34,17 @@
   --text-xxxxxl: calc(var(--text-xxxxl) * var(--text-scale-ratio)); // ~42px
 }
 
+@mixin line-heights {
+  --line-height-none:     0;
+  --line-height-tightest: 1;
+  --line-height-tighter:  1.15;
+  --line-height-tight:    1.3;
+  --line-height-base:     1.5;
+  --line-height-loose:    1.6;
+  --line-height-looser:   1.7;
+  --line-height-loosest:  1.8;
+}
+
 @mixin spacing-scales {
   // This is using the Golden Ratio to get these numbers
   // Visit https://codyhouse.co/ds/globals/spacing to play around with different ratios
@@ -62,6 +73,9 @@
 
   // Text Ratios
   @include text-scales;
+
+  // Line heights
+  @include line-heights;
 
   // Spacing
   @include spacing-scales;

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/tokens.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/tokens.scss
@@ -2,13 +2,18 @@
 // as needed and override them.
 
 @mixin border-radius {
-  -radius-xs:  2px;
+  --radius-xs:  2px;
   --radius-sm:  4px;
   --radius-md:  8px;
-  --radius:     16px;
-  --radius-lg:  24px;
-  --radius-xl:  48px;
+  --radius:     12px;
+  --radius-lg:  16px;
+  --radius-xl:  20px;
   --radius-max: 50%;
+}
+
+@mixin border-width {
+  --border-width: 2px;
+  --border-width-sm: 1px;
 }
 
 @mixin text-scales {
@@ -53,7 +58,7 @@
 :root {
   // Border
   @include border-radius;
-  --border-width: 2px;
+  @include border-width;
 
   // Text Ratios
   @include text-scales;


### PR DESCRIPTION
## Task

[TR #59](https://trello.com/c/HX4dt7Vc/59-e48-use-box-shadow-instead-of-border)
[TR #63](https://trello.com/c/ptvCQBQC/63-e48-remove-card-rounded)
[TR #65](https://trello.com/c/zLVmxAZb/65-e48-h-elements-should-reset-using-margin-0-instead-of-unset)
[TR #66](https://trello.com/c/lQU5vlKl/66-e48-structure-the-file-using-a-card)
[TR #78](https://trello.com/c/ucq5uZNW/78-import-line-height-variables-from-motz)
[TR #79](https://trello.com/c/0ygsOFiP/79-import-border-variables-from-motz)

## Why?

Implement a number of structure and styling simplifications to base card styles for easier and more consistent development and styling.

## What Changed

What changed in this PR?

* [ ] Adjusted `border-radius` tokens
* [ ] Added `line-height` tokens
* [ ] Refactored default card structure styling
* [ ] Begin replacing `borders` with `box-shadows` tokens
* [ ] Added simple documentation to `.card.scss`

## Screenshots

New border using `box-shadow` and adjusted `border-radius` scale
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/88258994/149594171-4083c34a-6f44-4afc-ab2d-3d8f8402c607.png">
