### PR TITLE
Add production.rb log level config via ENV Var

### DIFF
--- a/lib/generators/rolemodel/heroku/heroku_generator.rb
+++ b/lib/generators/rolemodel/heroku/heroku_generator.rb
@@ -14,5 +14,9 @@ module Rolemodel
     def force_ssl
       uncomment_lines('config/environments/production.rb', 'config.force_ssl = true')
     end
+
+    def enable_log_level_configurability
+      gsub_file('config/environments/production.rb', 'config.log_level = :info', "config.log_level = ENV.fetch('LOG_LEVEL', { 'INFO' })")
+    end
   end
 end


### PR DESCRIPTION
This adds to the Heroku generator a step to modify the `production.rb` file to allow the use of `LOG_LEVEL` env var to configure the production Rails log level.