### PR TITLE
[TR #81] Add separate concepts for layout row and flexible layout area

### DIFF
--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/utilities.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/utilities.scss
@@ -24,70 +24,35 @@
 
 .flex-wrap { flex-wrap: wrap; }
 
+.flex-no-wrap { flex-wrap: nowrap; }
+
 .flex-grow-1 { flex-grow: 1; }
 
-// Layout properties
-// E.G:
-// .flex.layout-row.gap-md
-//   .two-thirds-width.card Item
-//   .card Item
-//   .card Item
-
-// Normal width
-// |      Item     | | Item | | Item |
-// Mobile
-// | Item |
-// | Item |
-// | Item |
-
-// E.G:
-// .flex.layout-row.gap-md.flex-wrap
-//   .two-thirds-width.card Item
-//   .card Item
-//   .card Item
-
-// Normal width
-// |      Item     | | Item | | Item |
-// Mobile
-// |   Item   | | Item |
-// |        Item       |
-
-.layout-row {
-  & > * {
-    flex: 1;
-
-    &.four-fifths-width { flex-basis: calc(100% * 4/5); }
-    &.three-fifths-width { flex-basis: calc(100% * 3/5); }
-    &.two-fifths-width { flex-basis: calc(100% * 2/5); }
-    &.one-fifth-width { flex-basis: calc(100% * 1/5); }
-
-    &.three-quarters-width { flex-basis: calc(100% * 3/4); }
-    &.one-quarter-width { flex-basis: calc(100% * 1/4); }
-
-    &.two-thirds-width { flex-basis: calc(100% * 2/3); }
-    &.one-third-width { flex-basis: calc(100% * 1/3); }
-
-    &.full-width { flex-basis: 100%; }
-    &.half-width { flex-basis: 50%; }
-  }
-
-  @media screen and (max-width: $breakpoint-sm) {
-    flex-wrap: wrap;
-
-    &:not(.flex-wrap) > * {
-      flex-basis: 100%;
-      width: 100%;
-    }
-  }
-}
-
 // Gap Properties
-.gap-xxs { gap: var(--space-xxs); }
-.gap-xs { gap: var(--space-xs); }
-.gap-sm { gap: var(--space-xxs); }
-.gap-md { gap: var(--space-md); }
-.gap-lg { gap: var(--space-lg); }
-.gap-xl { gap: var(--space-xl); }
+.gap-xxs {
+  gap: var(--space-xxs);
+  --gap: var(--space-xxs);
+}
+.gap-xs {
+  gap: var(--space-xs);
+  --gap: var(--space-xs);
+}
+.gap-sm {
+  gap: var(--space-sm);
+  --gap: var(--space-sm);
+}
+.gap-md {
+  gap: var(--space-md);
+  --gap: var(--space-md);
+}
+.gap-lg {
+  gap: var(--space-lg);
+  --gap: var(--space-lg);
+}
+.gap-xl {
+  gap: var(--space-xl);
+  --gap: var(--space-xl);
+}
 
 // Justify Content
 
@@ -192,33 +157,15 @@
 
 // Box Margin
 
-.margin-xl {
-  margin: var(--space-xl);
-}
+.margin-xl { margin: var(--space-xl); }
+.margin-lg { margin: var(--space-lg); }
+.margin-md { margin: var(--space-md); }
+.margin-sm { margin: var(--space-sm); }
+.margin-xs { margin: var(--space-xs); }
 
-.margin-lg {
-  margin: var(--space-lg);
-}
+.margin-none { margin: 0; }
 
-.margin-md {
-  margin: var(--space-md);
-}
-
-.margin-sm {
-  margin: var(--space-sm);
-}
-
-.margin-xs {
-  margin: var(--space-xs);
-}
-
-.margin-none {
-  margin: 0;
-}
-
-.margin-auto {
-  margin: auto;
-}
+.margin-auto { margin: auto; }
 
 // Vertical Margin
 
@@ -286,107 +233,39 @@
 
 // Top Margin
 
-.margin-top-xl {
-  margin-top: var(--space-xl);
-}
-
-.margin-top-lg {
-  margin-top: var(--space-lg);
-}
-
-.margin-top-md {
-  margin-top: var(--space-md);
-}
-
-.margin-top-sm {
-  margin-top: var(--space-sm);
-}
-
-.margin-top-xs {
-  margin-top: var(--space-xs);
-}
-
-.margin-top-none {
-  margin-top: 0;
-}
+.margin-top-xl { margin-top: var(--space-xl); }
+.margin-top-lg { margin-top: var(--space-lg); }
+.margin-top-md { margin-top: var(--space-md); }
+.margin-top-sm { margin-top: var(--space-sm); }
+.margin-top-xs { margin-top: var(--space-xs); }
+.margin-top-none { margin-top: 0; }
 
 // Bottom Margin
 
-.margin-bottom-xl {
-  margin-bottom: var(--space-xl);
-}
-
-.margin-bottom-lg {
-  margin-bottom: var(--space-lg);
-}
-
-.margin-bottom-md {
-  margin-bottom: var(--space-md);
-}
-
-.margin-bottom-sm {
-  margin-bottom: var(--space-sm);
-}
-
-.margin-bottom-xs {
-  margin-bottom: var(--space-xs);
-}
-
-.margin-bottom-none {
-  margin-bottom: 0;
-}
+.margin-bottom-xl { margin-bottom: var(--space-xl); }
+.margin-bottom-lg { margin-bottom: var(--space-lg); }
+.margin-bottom-md { margin-bottom: var(--space-md); }
+.margin-bottom-sm { margin-bottom: var(--space-sm); }
+.margin-bottom-xs { margin-bottom: var(--space-xs); }
+.margin-bottom-none { margin-bottom: 0; }
 
 // Right Margin
 
-.margin-right-xl {
-  margin-right: var(--space-xl);
-}
-
-.margin-right-lg {
-  margin-right: var(--space-lg);
-}
-
-.margin-right-md {
-  margin-right: var(--space-md);
-}
-
-.margin-right-sm {
-  margin-right: var(--space-sm);
-}
-
-.margin-right-xs {
-  margin-right: var(--space-xs);
-}
-
-.margin-right-none {
-  margin-left: 0;
-}
+.margin-right-xl { margin-right: var(--space-xl); }
+.margin-right-lg { margin-right: var(--space-lg); }
+.margin-right-md { margin-right: var(--space-md); }
+.margin-right-sm { margin-right: var(--space-sm); }
+.margin-right-xs { margin-right: var(--space-xs); }
+.margin-right-none { margin-left: 0; }
 
 // Left Margin
 
-.margin-left-xl {
-  margin-left: var(--space-xl);
-}
-
-.margin-left-lg {
-  margin-left: var(--space-lg);
-}
-
-.margin-left-md {
-  margin-left: var(--space-md);
-}
-
-.margin-left-sm {
-  margin-left: var(--space-sm);
-}
-
-.margin-left-xs {
-  margin-left: var(--space-xs);
-}
-
-.margin-left-none {
-  margin-left: 0;
-}
+.margin-left-xl { margin-left: var(--space-xl); }
+.margin-left-lg { margin-left: var(--space-lg); }
+.margin-left-md { margin-left: var(--space-md); }
+.margin-left-sm { margin-left: var(--space-sm); }
+.margin-left-xs { margin-left: var(--space-xs); }
+.margin-left-none { margin-left: 0; }
 
 // Elevations
 .elevation-1, .elevation-1.card { box-shadow: var(--elevation-1); }
@@ -394,3 +273,114 @@
 .elevation-3, .elevation-3.card { box-shadow: var(--elevation-3); }
 .elevation-4, .elevation-4.card { box-shadow: var(--elevation-4); }
 .elevation-5, .elevation-5.card { box-shadow: var(--elevation-5); }
+
+// Layout properties
+// Layout row evenly spaces all elements within it.
+// It also makes it responsive at the sm breakpoint.
+// If you combine it with flex-wrap, it tries to break using the
+// normal flex wrap rules instead of responsively.
+
+// E.G:
+// .flex.layout-row
+//   .card Item
+//   .card Item
+//   .card Item
+
+// Normal width
+// | Item | | Item | | Item |
+// Mobile
+// | Item |
+// | Item |
+// | Item |
+
+// E.G:
+// .flex.layout-row.flex-wrap
+//   .card Item
+//   .card Item
+
+// Normal width
+// | Item | | Item | | Item |
+// Mobile (really small)
+// | Item | | Item |
+// |      Item     |
+.layout-row {
+  & > * {
+    flex: 1;
+  }
+
+  @media screen and (max-width: $breakpoint-sm) {
+    // Use flex wrapping strategy instead of responsive wrapping at sm breakpoint.
+    &:not(.flex-wrap) {
+      flex-direction: column;
+    }
+  }
+}
+
+// Flexible Layout
+// This allows for creating a grid like area using one flex container with multiple lines
+// Percentage based widths can be used to define the areas of each row.
+// Note: This responsively breaks at $breakpoint-sm to a single column.
+// You can add the .flex-no-wrap class to prevent that.
+// This can also be combined with .gap-{size} to space items without having
+// them wrap when you don't want them to.
+
+// E.G
+// | One Fifth | | One Fifth | | One Fifth | | One Fifth | | One Fifth |
+// | One Quarter  | | One Quarter  | |  One Quarter  | |  One Quarter  |
+// |      One Third      | |      One Third      | |     One Third     |
+// |            One Half            | |            One Half            |
+// |                              One Full                             |
+// Mobile
+// | Item |
+// | Item |
+// | Item |
+// | Item |
+// | Item |
+// | Item |
+// | Item |
+// | Item |
+// | Item |
+// | Item |
+// | Item |
+// | Item |
+// | Item |
+// | Item |
+// | Item |
+
+// .flexible-layout-area can be nested in the item of another .flexible-layout-area
+// for a more complex layout if needed. Gaps are not inherited and will need
+// to be redefined at each level
+
+.flexible-layout-area {
+  display: flex;
+  flex-wrap: wrap;
+
+  & > * {
+    flex: 1;
+
+    &.four-fifths-width { flex-basis: calc(calc(100% * 4/5) - var(--gap)); }
+    &.three-fifths-width { flex-basis: calc(calc(100% * 3/5) - var(--gap)); }
+    &.two-fifths-width { flex-basis: calc(calc(100% * 2/5) - var(--gap)); }
+    &.one-fifth-width { flex-basis: calc(calc(100% * 1/5) - var(--gap)); }
+
+    &.three-quarters-width { flex-basis: calc(calc(100% * 3/4) - var(--gap)); }
+    &.one-quarter-width { flex-basis: calc(calc(100% * 1/4) - var(--gap)); }
+
+    &.two-thirds-width { flex-basis: calc(calc(100% * 2/3) - var(--gap)); }
+    &.one-third-width { flex-basis: calc(calc(100% * 1/3) - var(--gap)); }
+
+    &.full-width { flex-basis: calc(100% - var(--gap)); }
+    &.half-width { flex-basis: calc(50% - var(--gap)); }
+  }
+
+  @media screen and (max-width: $breakpoint-sm) {
+    &:not(.flex-no-wrap) {
+      flex-direction: column;
+
+      & > * {
+        flex-basis: 100%;
+        width: 100%;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Task

[TR #81](https://trello.com/c/r7I7rdwk)

## Why?

The layout-row utility was overloaded and doing more than it should have.

It needs to be simplified and a new concept `flexible-layout-area` needs to be added to clearly separate the concepts and add documentation.

## What Changed

* [X] Simplify layout-row
* [X] Add flexible-layout-area
* [X] Add documentation to both
* [X] Move layout utilities to the bottom of the file.
* [X] Fix gap-sm helper (was pointing at xxs spacing)

## Screenshots

![Screen Shot 2022-02-08 at 10 23 42 AM](https://user-images.githubusercontent.com/5957102/153018505-28ef44a6-4de3-4a0b-99c0-54e4a31dd013.png)
![Screen Shot 2022-02-08 at 10 23 48 AM](https://user-images.githubusercontent.com/5957102/153018508-47620f4e-9617-4c8c-915c-120346055cd2.png)
![Screen Shot 2022-02-08 at 10 24 15 AM](https://user-images.githubusercontent.com/5957102/153018512-0ff9f29c-0db4-4d99-8d10-1f30186c7cf5.png)
![Screen Shot 2022-02-08 at 10 24 20 AM](https://user-images.githubusercontent.com/5957102/153018513-d9372e04-3284-42cb-9445-ae6682593b6a.png)

