### PR TITLE
Add production default mailer config

### DIFF
--- a/lib/generators/rolemodel/mailers/USAGE
+++ b/lib/generators/rolemodel/mailers/USAGE
@@ -15,6 +15,7 @@ Example:
 
     This will modify:
         config/environments/development.rb
+        config/environments/production.rb
 
     This will remove:
         app/views/layouts/mailer.html.erb

--- a/lib/generators/rolemodel/mailers/mailers_generator.rb
+++ b/lib/generators/rolemodel/mailers/mailers_generator.rb
@@ -40,6 +40,42 @@ module Rolemodel
       end
     end
 
+    def add_production_mailer_defaults
+      prepend_to_file 'config/environments/production.rb', "require Rails.root.join('app/mailers/staging_mailer_interceptor')\n"
+
+      inject_into_file 'config/environments/production.rb', after: "config.action_mailer.perform_caching = false\n" do
+        optimize_indentation <<~'RUBY', 2
+          host = if ENV['REVIEW_APP'] == 'true' && ENV['HEROKU_APP_NAME'].present?
+            "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
+          else
+            ENV['PRODUCTION_HOST']
+          end
+
+          # Prevent live user emails from being sent out in staging
+          if ENV['WHITELISTED_EMAILS'].present?
+            ActionMailer::Base.register_interceptor(StagingMailerInterceptor)
+          end
+
+          # Ensure premailer_rails can point to webpack compiled resources
+          # https://github.com/fphilipe/premailer-rails/issues/232#issuecomment-839819705
+          config.action_mailer.asset_host = host
+
+          config.action_mailer.default_url_options = { host: host }
+          config.action_mailer.delivery_method = :smtp
+          config.action_mailer.perform_deliveries = true
+          config.action_mailer.smtp_settings = {
+            user_name: 'apikey',
+            password: ENV['SENDGRID_API_KEY'],
+            domain: ENV['PRODUCTION_HOST'],
+            address: 'smtp.sendgrid.net',
+            port: 587,
+            authentication: :plain,
+            enable_starttls_auto: true
+          }
+        RUBY
+      end
+    end
+
     def add_mailer_css
       copy_file 'app/javascript/packs/mailer_stylesheets.scss'
     end

--- a/lib/generators/rolemodel/mailers/templates/app/mailers/staging_mailer_interceptor.rb
+++ b/lib/generators/rolemodel/mailers/templates/app/mailers/staging_mailer_interceptor.rb
@@ -1,0 +1,8 @@
+class StagingMailerInterceptor
+  def self.delivering_email(message)
+    whitelisted_emails = ENV['WHITELISTED_EMAILS'].split(',').map(&:strip)
+    message.to = message.to & whitelisted_emails
+    message.subject = "STAGING - #{message.subject}"
+    message.perform_deliveries = false if message.to.blank?
+  end
+end


### PR DESCRIPTION
## Why?

Pull in our default production mailer config. This also includes a fix for premailer to get the right asset host set

## What Changed

What changed in this PR?

* [x] Fix premailer asset host issue with image tag for logos 
* [x] Add in default sendgrid config to production
* [x] Add staging whitelist emails interceptor
