### PR TITLE
Miscellaneous fixes

### DIFF
--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/utilities.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/utilities.scss
@@ -389,8 +389,8 @@
 }
 
 // Elevations
-.elevation-1 { box-shadow: var(--elevation-1); }
-.elevation-2 { box-shadow: var(--elevation-2); }
-.elevation-3 { box-shadow: var(--elevation-3); }
-.elevation-4 { box-shadow: var(--elevation-4); }
-.elevation-5 { box-shadow: var(--elevation-5); }
+.elevation-1, .elevation-1.card { box-shadow: var(--elevation-1); }
+.elevation-2, .elevation-2.card { box-shadow: var(--elevation-2); }
+.elevation-3, .elevation-3.card { box-shadow: var(--elevation-3); }
+.elevation-4, .elevation-4.card { box-shadow: var(--elevation-4); }
+.elevation-5, .elevation-5.card { box-shadow: var(--elevation-5); }

--- a/lib/generators/rolemodel/css/base/templates/app/views/styleguide/index.html.slim
+++ b/lib/generators/rolemodel/css/base/templates/app/views/styleguide/index.html.slim
@@ -136,44 +136,40 @@
     .card__body
       .flex.layout-row.gap-md.flex-wrap
         .card
-          .card__header
-            span Just a Card
-          .card__body
+          span Just a Card
+          div
             code .card
-        .card
-          .card__header
-            span Outlined Card
-          .card__body
-            code .card
-        .card.elevation-1
+        .card.card--padded
+          span Padded Card
+          div
+            code .card.card--padded
+        .card.elevation-3
           .card__header
             span Elevated Card
           .card__body
-            code .card.elevation-1
-        .card
-          .card__header
-            span Rounded Card
-          .card__body
-            code .card
-      .flex.layout-row.gap-md.flex-wrap.margin-top-sm
-        .card
-          .card__header.background-primary-lighter
-            h3 Colored with header and body
-          .card__body.background-primary-lightest
-            pre
-              div .card
-              div.margin-left-sm .card__header.background-primary-lighter
-              div.margin-left-sm .card__body.background-primary-lightest
-        .card.elevation-3
-          .card__header.background-primary-darker
-            .flex.justify-between.items-center
-              h3 Styled
-              button.btn.btn--primary = icon('edit')
-          .card__body.background-primary-dark
-            pre
-              div .card.elevation-3
-              div.margin-left-sm .card__header.background-primary-darker
-              div.margin-left-sm .card__body.background-primary-dark
+            code .card.elevation-3
+
+      .card.margin-top-md
+        .card__header.background-primary-lighter
+          h3 Colored with header and body
+        .card__body.background-primary-lightest
+          pre
+            div .card
+            div.margin-left-sm .card__header.background-primary-lighter
+            div.margin-left-sm .card__body.background-primary-lightest
+      .card.elevation-3.margin-top-md
+        .card__header.background-primary-darker
+          .flex.justify-between.items-center
+            h3 Styled
+            button.btn.btn--primary = icon('edit')
+        .card__body.background-primary-dark
+          pre
+            div .card.elevation-3
+            div.margin-left-sm .card__header.background-primary-darker
+            div.margin-left-sm .card__body.background-primary-dark
+            div.margin-left-sm .card__footer.background-primary-base
+        .card__footer.background-primary-base
+          span Footer
 
   section.card.margin-top-md
     .card__header.background-primary-lightest

--- a/lib/generators/rolemodel/css/base/templates/app/views/styleguide/index.html.slim
+++ b/lib/generators/rolemodel/css/base/templates/app/views/styleguide/index.html.slim
@@ -2,7 +2,7 @@
   h1 Basic Style Guide Demo
 
   .flex.layout-row.gap-md
-    section.card.card--outlined.margin-top-md
+    section.card.margin-top-md
       .card
         .card__header.background-primary-lightest
           h2.styleguide-section__title Typography
@@ -18,7 +18,7 @@
           .font-xs --text-xs - Heading 6 - 14px
           .font-xxs --text-xxs - 12px
 
-    section.card.card--outlined.margin-top-md
+    section.card.margin-top-md
       .card__header.background-primary-lightest
         h2.styleguide-section__title Spacing Reference
       .card__body
@@ -45,7 +45,7 @@
             .spacing-example style="width: var(--space-xl)"
             span --space-xl (42px)
 
-  section.card.card--outlined.margin-top-md
+  section.card.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Color Scales
       p Usage --color-"scale"-"number". Example --color-secondary-30
@@ -70,7 +70,7 @@
         h4 Neutral Variant
         = render 'shared/color_scale', scale_name: 'neutral-variant', text_color: 'background'
 
-  section.card.card--outlined.margin-top-md
+  section.card.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Semantic Colors
     .card__body
@@ -101,7 +101,7 @@
           .swatch.elevation-1 style="background: var(--color-on-background); color: var(--color-background)" On Background (Neutral 10)
           .swatch.elevation-1 style="background: var(--color-outline); color: var(--color-background)" Outline (Neutral Variant 80)
 
-  section.card.card--outlined.margin-top-md
+  section.card.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Text Colors
       p Badges
@@ -130,7 +130,7 @@
           .swatch style="background: var(--color-notice-#{color})"
             span = "--color-notice-#{color}"
 
-  section.card.card--outlined.margin-top-md
+  section.card.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Cards
     .card__body
@@ -140,21 +140,21 @@
             span Just a Card
           .card__body
             code .card
-        .card.card--outlined
+        .card
           .card__header
             span Outlined Card
           .card__body
-            code .card.card--outlined
+            code .card
         .card.elevation-1
           .card__header
             span Elevated Card
           .card__body
             code .card.elevation-1
-        .card.card--outlined
+        .card
           .card__header
             span Rounded Card
           .card__body
-            code .card.card--outlined
+            code .card
       .flex.layout-row.gap-md.flex-wrap.margin-top-sm
         .card
           .card__header.background-primary-lighter
@@ -175,7 +175,7 @@
               div.margin-left-sm .card__header.background-primary-darker
               div.margin-left-sm .card__body.background-primary-dark
 
-  section.card.card--outlined.margin-top-md
+  section.card.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Elevations
     .card__body
@@ -187,7 +187,7 @@
         .card.card--padded.elevation-4 Elevation 4
         .card.card--padded.elevation-5 Elevation 5
 
-  section.card.card--outlined.margin-top-md
+  section.card.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Button
     .card__body
@@ -216,7 +216,7 @@
         a.btn.btn--outline.btn--tertiary.btn--rounded Tertiary Rounded
         a.btn.btn--outline.btn--tertiary.btn--small Tertiary Small
 
-  section.card.card--outlined.margin-top-md
+  section.card.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Form
     .card__body
@@ -280,7 +280,7 @@
           input.form__radio id="form-radio-disabled-checked" type="radio" name="disabled-radio" value="1" disabled="disabled" checked="checked"
           label.form__label for="form-radio-disabled-checked" Radio Disabled checked
 
-  section.card.card--outlined.margin-top-md
+  section.card.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title flash
     .card__body
@@ -315,7 +315,7 @@
             .flash__message-type Warning
             .flash__message .flash.flash--warning
 
-  section.card.card--outlined.margin-top-md
+  section.card.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Tables
     .card__body
@@ -396,7 +396,7 @@
                 td.text-right
                   a.btn.btn--outline.btn--small Label
 
-  section.card.card--outlined.margin-top-md
+  section.card.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Icons
     .card__body

--- a/lib/generators/rolemodel/css/base/templates/app/views/styleguide/index.html.slim
+++ b/lib/generators/rolemodel/css/base/templates/app/views/styleguide/index.html.slim
@@ -2,7 +2,7 @@
   h1 Basic Style Guide Demo
 
   .flex.layout-row.gap-md
-    section.card.card--rounded.card--outlined.margin-top-md
+    section.card.card--outlined.margin-top-md
       .card
         .card__header.background-primary-lightest
           h2.styleguide-section__title Typography
@@ -18,7 +18,7 @@
           .font-xs --text-xs - Heading 6 - 14px
           .font-xxs --text-xxs - 12px
 
-    section.card.card--rounded.card--outlined.margin-top-md
+    section.card.card--outlined.margin-top-md
       .card__header.background-primary-lightest
         h2.styleguide-section__title Spacing Reference
       .card__body
@@ -45,7 +45,7 @@
             .spacing-example style="width: var(--space-xl)"
             span --space-xl (42px)
 
-  section.card.card--rounded.card--outlined.margin-top-md
+  section.card.card--outlined.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Color Scales
       p Usage --color-"scale"-"number". Example --color-secondary-30
@@ -70,7 +70,7 @@
         h4 Neutral Variant
         = render 'shared/color_scale', scale_name: 'neutral-variant', text_color: 'background'
 
-  section.card.card--rounded.card--outlined.margin-top-md
+  section.card.card--outlined.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Semantic Colors
     .card__body
@@ -101,7 +101,7 @@
           .swatch.elevation-1 style="background: var(--color-on-background); color: var(--color-background)" On Background (Neutral 10)
           .swatch.elevation-1 style="background: var(--color-outline); color: var(--color-background)" Outline (Neutral Variant 80)
 
-  section.card.card--rounded.card--outlined.margin-top-md
+  section.card.card--outlined.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Text Colors
       p Badges
@@ -130,7 +130,7 @@
           .swatch style="background: var(--color-notice-#{color})"
             span = "--color-notice-#{color}"
 
-  section.card.card--rounded.card--outlined.margin-top-md
+  section.card.card--outlined.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Cards
     .card__body
@@ -150,11 +150,11 @@
             span Elevated Card
           .card__body
             code .card.elevation-1
-        .card.card--rounded.card--outlined
+        .card.card--outlined
           .card__header
             span Rounded Card
           .card__body
-            code .card.card--rounded.card--outlined
+            code .card.card--outlined
       .flex.layout-row.gap-md.flex-wrap.margin-top-sm
         .card
           .card__header.background-primary-lighter
@@ -164,18 +164,18 @@
               div .card
               div.margin-left-sm .card__header.background-primary-lighter
               div.margin-left-sm .card__body.background-primary-lightest
-        .card.card--rounded.elevation-3
+        .card.elevation-3
           .card__header.background-primary-darker
             .flex.justify-between.items-center
               h3 Styled
               button.btn.btn--primary = icon('edit')
           .card__body.background-primary-dark
             pre
-              div .card.card--rounded.elevation-3
+              div .card.elevation-3
               div.margin-left-sm .card__header.background-primary-darker
               div.margin-left-sm .card__body.background-primary-dark
 
-  section.card.card--rounded.card--outlined.margin-top-md
+  section.card.card--outlined.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Elevations
     .card__body
@@ -187,7 +187,7 @@
         .card.card--padded.elevation-4 Elevation 4
         .card.card--padded.elevation-5 Elevation 5
 
-  section.card.card--rounded.card--outlined.margin-top-md
+  section.card.card--outlined.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Button
     .card__body
@@ -216,7 +216,7 @@
         a.btn.btn--outline.btn--tertiary.btn--rounded Tertiary Rounded
         a.btn.btn--outline.btn--tertiary.btn--small Tertiary Small
 
-  section.card.card--rounded.card--outlined.margin-top-md
+  section.card.card--outlined.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Form
     .card__body
@@ -280,7 +280,7 @@
           input.form__radio id="form-radio-disabled-checked" type="radio" name="disabled-radio" value="1" disabled="disabled" checked="checked"
           label.form__label for="form-radio-disabled-checked" Radio Disabled checked
 
-  section.card.card--rounded.card--outlined.margin-top-md
+  section.card.card--outlined.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title flash
     .card__body
@@ -315,7 +315,7 @@
             .flash__message-type Warning
             .flash__message .flash.flash--warning
 
-  section.card.card--rounded.card--outlined.margin-top-md
+  section.card.card--outlined.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Tables
     .card__body
@@ -377,7 +377,7 @@
       .margin-top-sm
         h2.margin-y-md.margin-left-md Styled Table
 
-        .card.card--rounded.elevation-3
+        .card.elevation-3
           table.table.table--no-last-divider
             thead
               th.background-primary-lighter Column 1
@@ -396,7 +396,7 @@
                 td.text-right
                   a.btn.btn--outline.btn--small Label
 
-  section.card.card--rounded.card--outlined.margin-top-md
+  section.card.card--outlined.margin-top-md
     .card__header.background-primary-lightest
       h2.styleguide-section__title Icons
     .card__body

--- a/lib/generators/rolemodel/modals/templates/app/views/styleguide/_modals.html.slim
+++ b/lib/generators/rolemodel/modals/templates/app/views/styleguide/_modals.html.slim
@@ -1,4 +1,4 @@
-section.card.card--outlined.margin-top-md
+section.card.margin-top-md
   .card__header.background-primary-lightest
     h2.styleguide-section__title Modals
   .card__body

--- a/lib/generators/rolemodel/modals/templates/app/views/styleguide/_modals.html.slim
+++ b/lib/generators/rolemodel/modals/templates/app/views/styleguide/_modals.html.slim
@@ -1,4 +1,4 @@
-section.card.card--rounded.card--outlined.margin-top-md
+section.card.card--outlined.margin-top-md
   .card__header.background-primary-lightest
     h2.styleguide-section__title Modals
   .card__body


### PR DESCRIPTION
## Why?

I noticed some things got left around after recent refactors. Additionally, the elevation class was not working as I expected it to.

## What Changed

What changed in this PR?

* [X] Removed all references to `.card--rounded`
* [X] Removed all references to `.card--outlined`
* [X] Cleaned up the card section of the styleguide.
* [X] Add elevation + card override. Cards were refactored to use box-shadow as their outline. This conflicted with elevation causing it to not show at all on elements with the `.card` class. NOTE: This does mean if you put an elevation on a card, it will not have a border and elevation. @scriswell @zoopmaster If we want to handle this case, the special override could switch the card to use `border` for the outline, but I figured if you are setting elevation, you probably don't want an outline.

## Screenshots

![Screen Shot 2022-02-27 at 6 42 08 PM](https://user-images.githubusercontent.com/5957102/155905145-5df834e2-b19c-48b9-8983-b4123e53f757.png)
![Screen Shot 2022-02-27 at 6 42 16 PM](https://user-images.githubusercontent.com/5957102/155905146-4a3d3f85-92e0-488e-8e34-a02e27861443.png)
