### PR TITLE
[TR #58] Buttons Revisited

### DIFF
--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/base.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/base.scss
@@ -38,7 +38,7 @@ button {
   color: var(--color-black);
 }
 
-a:not(.btn):not(.sidebar-nav__item):not(.navigation-rail__item) {
+a {
   color: var(--color-primary);
 
   &:visited {

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/base.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/base.scss
@@ -26,6 +26,18 @@ button, input, optgroup, select, textarea {
   line-height: inherit;
 }
 
+button {
+  margin: 0;
+  border: 0;
+  outline: 0;
+  padding: 0;
+
+  background: none;
+  cursor: pointer;
+
+  color: var(--color-black);
+}
+
 a:not(.btn):not(.sidebar-nav__item):not(.navigation-rail__item) {
   color: var(--color-primary);
 

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/button.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/button.scss
@@ -33,6 +33,7 @@
   font-weight: 500;
   text-align: center;
   text-decoration: none;
+  color: var(--color-black);
 
   @media(max-width: $breakpoint-sm) {
     align-items: center;

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/button.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/button.scss
@@ -1,78 +1,89 @@
-button {
-  margin: 0;
-  padding: 0;
+// DOCS
 
-  cursor: pointer;
+// -- For a button with different variants --
+// Note: If you are using a variant like .btn--primary,
+// you do not need to include to base .btn
 
-  border: 0;
-  outline: 0;
-  background: none;
-  color: var(--color-black);
+// a.btn
+// button.btn
+// button.btn--primary
+// button.btn--primary.btn--outline.btn--small
+// button.btn--secondary.btn--large
+
+:root {
+  --mobile-min-height: 44px;
 }
 
-.btn {
-  --mobile-min-height: 44px;
-
-  cursor: pointer;
-
+%btn {
+  -webkit-appearance: none;
   display: inline-flex;
+
   justify-content: center;
 
-  padding: var(--text-xs) var(--text-sm);
-
   transition: all 120ms;
-  text-decoration: none;
-  text-align: center;
 
   border: 0;
   border-width: var(--border-width);
   border-radius: var(--radius);
+  padding: var(--space-sm) var(--space-md);
 
-  font-size: var(--text-sm);
+  cursor: pointer;
+
+  font-size: var(--text-xs);
   font-weight: 500;
-
-  -webkit-appearance: none;
+  text-align: center;
+  text-decoration: none;
 
   @media(max-width: $breakpoint-sm) {
-    min-height: var(--mobile-min-height);
     align-items: center;
+    min-height: var(--mobile-min-height);
   }
-
 }
 
+// Base Style
+.btn {
+  @extend %btn;
+}
+
+// Theme Styles
 .btn--primary {
+  @extend %btn;
+
   background: var(--color-primary-base);
   color: var(--color-on-primary-base);
 
   &:hover {
     background: var(--color-primary-hover);
-    color: var(--color-on-primary-hover);
   }
 }
 
 .btn--secondary {
+  @extend %btn;
+
   background: var(--color-secondary-base);
   color: var(--color-on-secondary-base);
 
   &:hover {
     background: var(--color-secondary-hover);
-    color: var(--color-on-secondary-hover);
   }
 }
 
 .btn--tertiary {
+  @extend %btn;
+
   background: var(--color-tertiary-base);
   color: var(--color-on-tertiary-base);
 
   &:hover {
     background: var(--color-tertiary-hover);
-    color: var(--color-on-tertiary-hover);
   }
 }
 
 .btn--outline {
-  border: var(--border-width) solid var(--color-outline);
+  @extend %btn;
+
   background: var(--color-background);
+  border: var(--border-width) solid var(--color-outline);
   color: var(--color-on-background);
 
   &:hover {
@@ -85,8 +96,7 @@ button {
     color: var(--color-primary-base);
 
     &:hover {
-      background: var(--color-primary-hover);
-      color: var(--color-on-primary-hover);
+      background: var(--color-primary-lightest);
     }
   }
 
@@ -95,8 +105,7 @@ button {
     color: var(--color-secondary-base);
 
     &:hover {
-      background: var(--color-secondary-hover);
-      color: var(--color-on-secondary-hover);
+      background: var(--color-secondary-lightest);
     }
   }
 
@@ -105,22 +114,34 @@ button {
     color: var(--color-tertiary-base);
 
     &:hover {
-      background: var(--color-tertiary-hover);
-      color: var(--color-on-tertiary-hover);
+      background: var(--color-tertiary-lightest);
     }
   }
 }
 
 .btn--small {
-  font-size: var(--text-sm);
-  padding: var(--space-xxs) var(--space-xs);
+  @extend %btn;
+
+  font-size: var(--text-xxs);
+  padding: var(--space-xs) var(--space-md);
 }
 
-.btn--rounded {
-  border-radius: var(--radius-xl);
+.btn--large {
+  @extend %btn;
+
+  font-size: var(--text-sm);
+  padding: var(--space-md) var(--space-lg);
+}
+
+.btn--pill {
+  @extend %btn;
+
+  border-radius: var(--radius-max);
 }
 
 .btn--active {
+  @extend %btn;
+
   background: var(--color-primary-base);
   color: var(--color-on-primary-base);
 

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/semantic_color_scales.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/semantic_color_scales.scss
@@ -10,7 +10,7 @@
     --color-#{$color}-lightest: var(--color-#{$color}-95);
     --color-#{$color}-lighter:  var(--color-#{$color}-80);
     --color-#{$color}-light:    var(--color-#{$color}-70);
-    --color-#{$color}-hover:     var(--color-#{$color}-50);
+    --color-#{$color}-hover:    var(--color-#{$color}-50);
     --color-#{$color}-base:     var(--color-#{$color}-40);
     --color-#{$color}-dark:     var(--color-#{$color}-30);
     --color-#{$color}-darker:   var(--color-#{$color}-20);
@@ -19,7 +19,7 @@
     --color-on-#{$color}-lightest: var(--color-#{$color}-10);
     --color-on-#{$color}-lighter:  var(--color-#{$color}-10);
     --color-on-#{$color}-light:    var(--color-#{$color}-0);
-    --color-on-#{$color}-hover:     var(--color-#{$color}-0);
+    --color-on-#{$color}-hover:    var(--color-#{$color}-0);
     --color-on-#{$color}-base:     var(--color-#{$color}-100);
     --color-on-#{$color}-dark:     var(--color-#{$color}-90);
     --color-on-#{$color}-darker:   var(--color-#{$color}-95);

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/tokens.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/tokens.scss
@@ -8,7 +8,7 @@
   --radius:     12px;
   --radius-lg:  16px;
   --radius-xl:  20px;
-  --radius-max: 50%;
+  --radius-max: 999px;
 }
 
 @mixin border-width {

--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/tokens.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/variables/tokens.scss
@@ -12,12 +12,11 @@
 }
 
 @mixin border-width {
-  --border-width: 2px;
-  --border-width-sm: 1px;
+  --border-width: 1px;
 }
 
 @mixin border-strokes {
-  --border-card-outline: 0 0 0 var(--border-width-sm) var(--color-outline);
+  --border-card-outline: 0 0 0 var(--border-width) var(--color-outline);
 }
 
 @mixin text-scales {


### PR DESCRIPTION
## Task

[TR #58](https://trello.com/c/DyO1hBwF)

## Why?

Structure the file using a `%btn` with base styles that extend `%btn` for button variants. Also, some of our button variants were outdated and needed some cleanup.

## What Changed

* [X] Change max radius token to use a large pixel value. This avoids strange behavior where % causes over rounding.
* [X] Change the default border width to 1px and remove the sm variant. Larger can be added on an as-needed by project basis.
* [X] Remove unnecessary base a tag style specificity.
* [X] Use `%btn` pattern for buttons to simplify usage (e.g. `.btn--primary` can be used without also needing `.btn`).
* [X] Prevent text color change on button hover
* [X] Make outlined button hover more subtle
* [X] Change `.btn--rounded` to `.btn--pill` since buttons are rounded (--radius 12px) by default and a "fully rounded" look is more like a pill.
* [X] Add large button variant
* [X] Adjust button font sizes and padding to scale better

## Screenshots

Old:
![Screen Shot 2022-03-01 at 6 41 29 PM](https://user-images.githubusercontent.com/5957102/156268299-254854df-5870-456f-85a4-098dee2d4f37.png)
![Screen Shot 2022-03-01 at 6 41 35 PM](https://user-images.githubusercontent.com/5957102/156268304-e61e079a-2f54-416a-8bb5-b05432ff67e6.png)
![Screen Shot 2022-03-01 at 6 41 38 PM](https://user-images.githubusercontent.com/5957102/156268305-1df91d46-024a-418a-9d2d-5f4da3906a65.png)


New:
![Screen Shot 2022-03-01 at 6 53 34 PM](https://user-images.githubusercontent.com/5957102/156268558-6d453cfb-dc63-46b2-851f-6635bb82c02a.png)
![Screen Shot 2022-03-01 at 6 53 38 PM](https://user-images.githubusercontent.com/5957102/156268559-6e8f7022-dc0b-4b24-845b-1eba2e60ed74.png)
