### PR TITLE
Fix visited link buttons and refactor to use loops

### DIFF
--- a/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/button.scss
+++ b/lib/generators/rolemodel/css/base/templates/app/javascript/stylesheets/components/button.scss
@@ -35,6 +35,10 @@
   text-decoration: none;
   color: var(--color-black);
 
+  &:visited {
+    color: var(--color-black);
+  }
+
   @media(max-width: $breakpoint-sm) {
     align-items: center;
     min-height: var(--mobile-min-height);
@@ -47,36 +51,21 @@
 }
 
 // Theme Styles
-.btn--primary {
-  @extend %btn;
+$button_varieties: 'primary', 'secondary', 'tertiary';
+@each $color in $button_varieties {
+  .btn--#{$color} {
+    @extend %btn;
 
-  background: var(--color-primary-base);
-  color: var(--color-on-primary-base);
+    background: var(--color-#{$color}-base);
+    color: var(--color-on-#{$color}-base);
 
-  &:hover {
-    background: var(--color-primary-hover);
-  }
-}
+    &:visited {
+      color: var(--color-on-#{$color}-base);
+    }
 
-.btn--secondary {
-  @extend %btn;
-
-  background: var(--color-secondary-base);
-  color: var(--color-on-secondary-base);
-
-  &:hover {
-    background: var(--color-secondary-hover);
-  }
-}
-
-.btn--tertiary {
-  @extend %btn;
-
-  background: var(--color-tertiary-base);
-  color: var(--color-on-tertiary-base);
-
-  &:hover {
-    background: var(--color-tertiary-hover);
+    &:hover {
+      background: var(--color-#{$color}-hover);
+    }
   }
 }
 
@@ -87,35 +76,27 @@
   border: var(--border-width) solid var(--color-outline);
   color: var(--color-on-background);
 
+  &:visited {
+    color: var(--color-on-background);
+  }
+
   &:hover {
     background: var(--color-neutral-variant-lightest);
     color: var(--color-on-neutral-variant-lightest);
   }
 
-  &.btn--primary {
-    border-color: var(--color-primary-base);
-    color: var(--color-primary-base);
+  @each $color in $button_varieties {
+    &.btn--#{$color} {
+      border-color: var(--color-#{$color}-base);
+      color: var(--color-#{$color}-base);
 
-    &:hover {
-      background: var(--color-primary-lightest);
-    }
-  }
+      &:visited {
+        color: var(--color-#{$color}-base);
+      }
 
-  &.btn--secondary {
-    border-color: var(--color-secondary-base);
-    color: var(--color-secondary-base);
-
-    &:hover {
-      background: var(--color-secondary-lightest);
-    }
-  }
-
-  &.btn--tertiary {
-    border-color: var(--color-tertiary-base);
-    color: var(--color-tertiary-base);
-
-    &:hover {
-      background: var(--color-tertiary-lightest);
+      &:hover {
+        background: var(--color-#{$color}-lightest);
+      }
     }
   }
 }
@@ -145,6 +126,10 @@
 
   background: var(--color-primary-base);
   color: var(--color-on-primary-base);
+
+  &:visited {
+    color: var(--color-on-primary-base);
+  }
 
   &:hover:not(:disabled) {
     background: var(--color-primary-base);


### PR DESCRIPTION
## Why?

After the button updates recently merged, a tags using any of the button styles did not have the correct text color when the :visited css was being applied.

## What Changed


* [X] Fix visited link buttons text color
* [X] Refactor styles to use a scss loop

## Screenshots

Old:
<img width="705" alt="Screen Shot 2022-03-10 at 2 06 57 PM" src="https://user-images.githubusercontent.com/5957102/157736674-809c6934-7144-40e6-8a92-53104b0307d0.png">

New:
<img width="298" alt="Screen Shot 2022-03-10 at 2 06 45 PM" src="https://user-images.githubusercontent.com/5957102/157736671-bccc1231-a89d-4555-9c0b-82de825caa85.png">
