### PR TITLE
Fix Custom Icon Clip Paths

### DIFF
--- a/lib/generators/rolemodel/css/icons/templates/config/webpack/loaders/svg-color-override-loader.js
+++ b/lib/generators/rolemodel/css/icons/templates/config/webpack/loaders/svg-color-override-loader.js
@@ -33,7 +33,17 @@ module.exports = function(content) {
         name: 'removeViewBox',
         active: false
       },
-      'removeDimensions'
+      'removeDimensions',
+      {
+        name: 'prefixIds',
+        params: {
+          delim: '-',
+          prefix: () => {
+            const pathParts = this.resourcePath.split('/')
+            return pathParts[pathParts.length - 1].replace('.svg', '')
+          }
+        }
+      }
     ])
   }
 

--- a/lib/generators/rolemodel/css/icons/templates/config/webpack/loaders/svg-color-override-loader.js
+++ b/lib/generators/rolemodel/css/icons/templates/config/webpack/loaders/svg-color-override-loader.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const { optimize, extendDefaultPlugins } = require('svgo')
 
 module.exports = function(content) {
@@ -38,10 +39,7 @@ module.exports = function(content) {
         name: 'prefixIds',
         params: {
           delim: '-',
-          prefix: () => {
-            const pathParts = this.resourcePath.split('/')
-            return pathParts[pathParts.length - 1].replace('.svg', '')
-          }
+          prefix: () => path.basename(this.resourcePath).replace('.svg', '')
         }
       }
     ])


### PR DESCRIPTION
## Why?
In an app I realized that the clip path ids were being optimized to the same thing no matter if they were different in the file definition.

## What Changed
* [x] add the prefix id plugin which prefixes the ids with the base file name

## Screenshots (The issue is with the bottom icon's hatch pattern)
Before
<img width="480" alt="Screen Shot 2022-11-18 at 3 53 13 PM" src="https://user-images.githubusercontent.com/39535618/202811388-490f3278-a23f-40f4-b3b6-27c7f6a2840e.png">
After
<img width="427" alt="Screen Shot 2022-11-18 at 3 45 03 PM" src="https://user-images.githubusercontent.com/39535618/202811395-94c6fd76-b72d-4102-b13b-a65a25849345.png">