### PR TITLE
Move Custom Cop to Lib

### DIFF
--- a/lib/generators/rolemodel/linters/rubocop/rubocop_generator.rb
+++ b/lib/generators/rolemodel/linters/rubocop/rubocop_generator.rb
@@ -19,7 +19,7 @@ module Rolemodel
 
       def add_config
         copy_file '.rubocop.yml'
-        copy_file 'app/cops/form_error_response.rb'
+        copy_file 'lib/cops/form_error_response.rb'
       end
     end
   end

--- a/lib/generators/rolemodel/linters/rubocop/templates/.rubocop.yml
+++ b/lib/generators/rolemodel/linters/rubocop/templates/.rubocop.yml
@@ -1,6 +1,6 @@
 require:
   - rubocop-rails
-  - ./app/cops/form_error_response.rb
+  - ./lib/cops/form_error_response.rb
 
 AllCops:
   Exclude:


### PR DESCRIPTION
## Why?

When the app tries to deploy, if the `rubocop` gem is `:development, :test`, Rails tries to load the `cops` folder which then looks for the Rubocop class, which doesn't exist. This moves the Cop to live under `lib` so that doesn't happen.

## What Changed

* [x] Update the generator to put the file under `lib`
* [x] Update the `rubocop.yml` config to point to `lib`