### PR TITLE
Add Kaminari

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ bin/rails g
   * [ESLint](./lib/generators/rolemodel/linters/eslint)
 * [Modals](./lib/generators/rolemodel/modals)
 * [Source Map](./lib/generators/rolemodel/source_map)
+* [Kaminari](./lib/generators/rolemodel/kaminari)
 
 ## Development
 

--- a/lib/generators/rolemodel/all_generator.rb
+++ b/lib/generators/rolemodel/all_generator.rb
@@ -18,6 +18,7 @@ module Rolemodel
       generate 'rolemodel:linters:all'
       generate 'rolemodel:mailers'
       generate 'rolemodel:source_map'
+      generate 'rolemodel:kaminari'
     end
   end
 end

--- a/lib/generators/rolemodel/kaminari/README.md
+++ b/lib/generators/rolemodel/kaminari/README.md
@@ -1,0 +1,14 @@
+# Kaminari Generator
+
+```
+rails g rolemodel:kaminari
+```
+
+## Depends On
+
+- `rolemodel:optics:base`
+- `rolemodel:optics:icons`
+
+## What you get
+
+Pulls in [Kaminari](https://github.com/kaminari/kaminari) along with templates that use the Optics Pagination Component.

--- a/lib/generators/rolemodel/kaminari/USAGE
+++ b/lib/generators/rolemodel/kaminari/USAGE
@@ -1,0 +1,5 @@
+Description:
+  Sets up our standard Kaminari configuration with Optics Pagination style applied
+
+Example:
+  rails generate rolemodel:kaminari

--- a/lib/generators/rolemodel/kaminari/kaminari_generator.rb
+++ b/lib/generators/rolemodel/kaminari/kaminari_generator.rb
@@ -1,0 +1,19 @@
+require_relative '../../bundler_helpers'
+
+module Rolemodel
+  class KaminariGenerator < Rails::Generators::Base
+    include Rolemodel::BundlerHelpers
+    source_root File.expand_path('templates', __dir__)
+
+    def install_kaminari
+      gem 'kaminari'
+      run_bundle
+
+      generate 'kaminari:config'
+    end
+
+    def copy_templates
+      directory 'app/views/kaminari'
+    end
+  end
+end

--- a/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_first_page.html.slim
+++ b/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_first_page.html.slim
@@ -1,0 +1,9 @@
+/ Link to the "First" page
+  - available local variables
+    url          : url to the first page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+
+== link_to_unless current_page.first?, material_icon('first_page'), url, remote: remote, class: 'btn btn--small btn--no-border btn--icon'

--- a/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_gap.html.slim
+++ b/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_gap.html.slim
@@ -1,0 +1,8 @@
+/ Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+
+.btn.btn--small.btn--no-border.btn--icon.btn--pagination-divider ...

--- a/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_last_page.html.slim
+++ b/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_last_page.html.slim
@@ -1,0 +1,9 @@
+/ Link to the "Last" page
+  - available local variables
+    url          : url to the last page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+
+== link_to_unless current_page.last?, material_icon('last_page'), url, remote: remote, class: 'btn btn--small btn--no-border btn--icon'

--- a/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_next_page.html.slim
+++ b/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_next_page.html.slim
@@ -1,0 +1,12 @@
+/ Link to the "Next" page
+  - available local variables
+    url          : url to the next page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+
+- unless current_page.last?
+  = link_to url, rel: 'next', remote: remote, class: 'btn btn--small btn--no-border' do
+    | Next
+    = material_icon('chevron_right')

--- a/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_page.html.slim
+++ b/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_page.html.slim
@@ -1,0 +1,10 @@
+/ Link showing page number
+  - available local variables
+    page         : a page object for "this" page
+    url          : url to this page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+
+= link_to page, url, { remote: remote, rel: page.rel, class: "btn btn--no-border btn--small #{'btn--active' if page.current? }" }

--- a/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_paginator.html.slim
+++ b/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_paginator.html.slim
@@ -1,0 +1,19 @@
+/ The container tag
+  - available local variables
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+    paginator    : the paginator that renders the pagination tags inside
+
+== paginator.render do
+  nav.pagination
+    == first_page_tag unless current_page.first?
+    == prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.display_tag?
+        == page_tag page
+      - elsif !page.was_truncated?
+        == gap_tag
+    == next_page_tag unless current_page.last?
+    == last_page_tag unless current_page.last?

--- a/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_prev_page.html.slim
+++ b/lib/generators/rolemodel/kaminari/templates/app/views/kaminari/_prev_page.html.slim
@@ -1,0 +1,12 @@
+/ Link to the "Previous" page
+  - available local variables
+    url          : url to the previous page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+
+- unless current_page.first?
+  = link_to url, rel: 'prev', remote: remote, class: 'btn btn--small btn--no-border' do
+    = material_icon('chevron_left')
+    | Prev

--- a/lib/generators/rolemodel/optics/all_generator.rb
+++ b/lib/generators/rolemodel/optics/all_generator.rb
@@ -1,5 +1,5 @@
 module Rolemodel
-  module Css
+  module Optics
     class AllGenerator < Rails::Generators::Base
       source_root File.expand_path('templates', __dir__)
 


### PR DESCRIPTION
## Why?

[Kaminari](https://github.com/kaminari/kaminari) is a tool we commonly use for paginating data. Optics is adding some styling around pagination so this generator configures your application to use the correct styling.

## What Changed

* [X] Fix Optics All Generator to use the correct module
* [X] Add Kaminari generator

## Note

This relies on https://github.com/RoleModel/optics/pull/175 which is not released yet. It should be fine for the time being though