### PR TITLE
Remove Semaphore --expire-in Flag

### DIFF
--- a/lib/generators/rolemodel/semaphore/templates/semaphore.yml.erb
+++ b/lib/generators/rolemodel/semaphore/templates/semaphore.yml.erb
@@ -82,7 +82,7 @@ blocks:
             - test-results publish tmp/test_results
         on_fail:
           commands:
-            - artifact push job log/test.log --expire-in 2w
+            - artifact push job log/test.log
   - name: Assets Compile
     dependencies:
       - Build
@@ -124,8 +124,8 @@ blocks:
             - cache delete assets-public-$SEMAPHORE_WORKFLOW_ID
         on_fail:
           commands:
-            - artifact push job log/test.log --expire-in 2w
-            - artifact push workflow tmp/capybara --expire-in 2w
+            - artifact push job log/test.log
+            - artifact push workflow tmp/capybara
 after_pipeline:
   task:
     jobs:


### PR DESCRIPTION
## Why?
This flag is not relevant anymore because it does nothing. All new projects don't need this set.