### PR TITLE
Modals Generator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rolemodel_rails (0.6.0)
+    rolemodel_rails (0.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rolemodel_rails (0.6.1)
+    rolemodel_rails (0.6.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/generators/rolemodel/modals/modals_generator.rb
+++ b/lib/generators/rolemodel/modals/modals_generator.rb
@@ -1,5 +1,3 @@
-
-
 module Rolemodel
   class ModalsGenerator < Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
@@ -35,24 +33,12 @@ module Rolemodel
     def amend_stylesheet_entrypoint
       say 'importing Optics stylesheets and defining custom properties', :green
 
-      inject_into_file 'app/assets/stylesheets/application.scss', after: "@import '@rolemodel/optics/dist/scss/optics';\n" do
+      inject_into_file 'app/assets/stylesheets/application.scss',
+                       after: "@import '@rolemodel/optics/dist/scss/optics';\n" do
         <<~SCSS
-          @import '@rolemodel/optics/dist/scss/addons/rails-modal-and-panel/modal';
-          @import '@rolemodel/optics/dist/scss/addons/rails-modal-and-panel/panel';
+          @import '@rolemodel/optics/dist/scss/addons/panel';
         SCSS
       end
-
-      append_to_file 'app/assets/stylesheets/application.scss', <<~SCSS
-        root {
-          // Panel tokens
-          --panel-width: 40%;
-          --panel-transition-speed: 400ms;
-
-          // Modals tokens
-          --modal-width: 564px;
-          --modal-transition-speed: 300ms;
-        }
-      SCSS
     end
 
     def amend_application_layout

--- a/lib/generators/rolemodel/modals/templates/app/views/layouts/modal.html.slim.tt
+++ b/lib/generators/rolemodel/modals/templates/app/views/layouts/modal.html.slim.tt
@@ -8,19 +8,23 @@ html
     = javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true
   body
     = turbo_frame_tag 'modal' do
-      .modal.flex.items-center.justify-center(
-        class=class_names('modal--active' => response.message == 'Unprocessable Entity')
+      .modal-wrapper(
+        class=class_names('modal-wrapper--active' => response.message == 'Unprocessable Entity')
         data-controller="toggle"
         data-toggle-perform-on-connect-value=(response.message == 'OK')
-        data-toggle-active-class="modal--active"
+        data-toggle-active-class="modal-wrapper--active"
         data-turbo-cache="false"
+        data-action="keydown.esc@window->toggle#off"
       )
-        .modal__backdrop data-action="click->toggle#perform"
-        .modal__content data-testid="modal-content"
+        .modal-wrapper__backdrop data-action="click->toggle#off"
+        .modal data-testid="modal-content"
           .modal__header
             = yield :modal_title
+            = button_tag( material_icon('close', size: 'x-large'), class: 'btn btn--no-border btn--icon btn--pill', data: { action: "toggle#off" })
+
           .modal__body
             = yield
+
           .modal__footer
-            = button_tag( 'Cancel', class: 'btn', data: { action: "toggle#perform" })
+            = button_tag( 'Cancel', class: 'btn', data: { action: "toggle#off" })
             = yield :modal_actions

--- a/lib/rolemodel_rails/version.rb
+++ b/lib/rolemodel_rails/version.rb
@@ -1,3 +1,3 @@
 module RolemodelRails
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end


### PR DESCRIPTION
## Task

Fix modal issues noted in #100 

## Why?

The modals generator was not pointing to the correct files and the template was not up to date.
Since Optics provides the modal as a full component now instead of an addon, these needed to be updated.

There might be a future PR to start using the `dialog` element, but there is further discussion needed on it.

## What Changed

* [X] Clean up injected styles
* [X] Use Optics template for modal
