### PR TITLE
modal_link_to optional second argument (fix #109)

### DIFF
--- a/lib/generators/rolemodel/modals/templates/app/helpers/turbo_frame_link_helper.rb
+++ b/lib/generators/rolemodel/modals/templates/app/helpers/turbo_frame_link_helper.rb
@@ -1,9 +1,9 @@
 module TurboFrameLinkHelper
-  def panel_link_to(name, url, options={}, &block)
+  def panel_link_to(name, url=nil, options={}, &block)
     frame_link_helper('panel', name, url, options, &block)
   end
 
-  def modal_link_to(name, url, options={}, &block)
+  def modal_link_to(name, url=nil, options={}, &block)
     frame_link_helper('modal', name, url, options, &block)
   end
 

--- a/lib/rolemodel_rails/version.rb
+++ b/lib/rolemodel_rails/version.rb
@@ -1,3 +1,3 @@
 module RolemodelRails
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
## Task

Fix Issue #109 

## Why?

modal_link_to & panel_link_to required 2 arguments, while link_to only requires 1.

## What Changed

What changed in this PR?

* [x] make the second argument optional
