### PR TITLE
[TR 89] Remove redundant section in pull_request_template.md

### DIFF
--- a/lib/generators/rolemodel/github/templates/pull_request_template.md
+++ b/lib/generators/rolemodel/github/templates/pull_request_template.md
@@ -1,7 +1,3 @@
-## Task
-
-[TR #XXX]()
-
 ## Why?
 
 Why were the changes needed? What issues were the changes addressing?


### PR DESCRIPTION
## Why?

When using Trello's Github Power-Up, the link is added automatically in a comment. Also, we typically add the Trello Card Number in the PR title.

## What Changed

What changed in this PR?

* [ ] Removed part of the Github Pull Request template

## Screenshots

If any UI changes need to be shown off, please add screenshots here.
