### PR TITLE
Fix Rspec rails helper asset precompile step

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,6 @@ The rolemodel_rails gem expects to be added to an existing Rails project. Typica
 rails new <app-name> --javascript=webpack --css=sass --database=postgresql --skip-test
 ```
 
-The Rspec generators require a railtie rake task to exist before running.
-
-Rspec hooks into `rails test:prepare` which doesn't exist due to using `--skip-test` in the new app generator. To add it back, remove all the imports at the top of `config/application.rb` and replace with:
-
-```ruby
-require_relative "boot"
-
-require "rails/all"
-```
-
 The Devise generator requires your database to exist before running.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ The rolemodel_rails gem expects to be added to an existing Rails project. Typica
 rails new <app-name> --javascript=webpack --css=sass --database=postgresql --skip-test
 ```
 
+The Rspec generators require a railtie rake task to exist before running.
+
+Rspec hooks into `rails test:prepare` which doesn't exist due to using `--skip-test` in the new app generator. To add it back, remove all the imports at the top of `config/application.rb` and replace with:
+
+```ruby
+require_relative "boot"
+
+require "rails/all"
+```
+
 The Devise generator requires your database to exist before running.
 
 ```shell

--- a/lib/generators/rolemodel/testing/rspec/templates/rails_helper.rb
+++ b/lib/generators/rolemodel/testing/rspec/templates/rails_helper.rb
@@ -63,7 +63,7 @@ RSpec.configure do |config|
 
   config.before :example, type: :system do
     unless ENV['ASSET_PRECOMPILE_SUCCESSFUL']
-      prep_passed = system 'rails test:prepare'
+      prep_passed = system 'rails spec:prepare'
       ENV['ASSET_PRECOMPILE_SUCCESSFUL'] = 'true'
 
       abort "\nYour assets didn't compile. Exiting WITHOUT running any tests. Review the output above to resolve any errors." unless prep_passed


### PR DESCRIPTION
## Why?

There is a very confusing side affect when you run `rails new` with `--skip-test` (since we use Rspec instead). In the latest versions of rails it will cause system tests to throw the following error

```shell
Unrecognized command "test:prepare" (Rails::Command::UnrecognizedCommandError)
Did you mean?  test:helpers
```

Using `--skip-test` generates `config/application.rb` with

```ruby
require_relative "boot"

require "rails"
# Pick the frameworks you want:
require "active_model/railtie"
require "active_job/railtie"
require "active_record/railtie"
require "active_storage/engine"
require "action_controller/railtie"
require "action_mailer/railtie"
require "action_mailbox/engine"
require "action_text/engine"
require "action_view/railtie"
require "action_cable/engine"
# require "rails/test_unit/railtie"
```

Notice that last commented out line...
If you don't skip tests, it generates

```ruby
require_relative "boot"

require "rails/all"
```

The issue is that test:prepare is a placeholder rake task brought in by `rails/test_unit/railtie` that rspec hooks into and adds the asset precompiling behavior to system tests. By skipping tests, it doesn't include this rake task which causes Rspec to fail.

## What Changed

* [X] Add directions to the Readme to add back the needed railtie require
