### PR TITLE
Improve Premailer initializer to avoid breaking premailer when using Optics

### DIFF
--- a/lib/generators/rolemodel/mailers/templates/config/initializers/premailer_rails.rb
+++ b/lib/generators/rolemodel/mailers/templates/config/initializers/premailer_rails.rb
@@ -2,7 +2,7 @@ module CustomPropertyCSSHelper
   def load_css(url)
     # strip out any CSS Custom Properties, PostCSS includes the fallbacks,
     # but Premailer can't ignore them so we remove them
-    super.gsub(/(\b[a-z_-]*?:[^\n;{}]*var\(.*?)?\B--.*?(;|(?=\}))/, '')
+    super.gsub(/((\b[a-z_-]*?:)?[^\n;{}]*var\(.*?)?\B--.*?(,(?=\n)|;(?!\S)|(?=\}))/, '')
   end
 end
 


### PR DESCRIPTION
## Why?

The default regex given to remove CSS Custom Properties before passing CSS to Premailer-Rails failed to fully match some complex syntaxes, and corrupted the resulting stylesheet.

## What Changed

What changed in this PR?

- [x] Added support for recognizing internal semicolons (such as in data urls)
```css
  --op-encoded-images-dropdown-arrow: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOSIgdmlld0JveD0iMCAwIDEyIDkiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik02IDguMzc1MDFMMCAyLjM3NTAxTDEuNCAwLjk3NTAwNkw2IDUuNTc1MDFMMTAuNiAwLjk3NTAwNkwxMiAyLjM3NTAxTDYgOC4zNzUwMVoiIGZpbGw9IiMwQTBBMEIiLz4KPC9zdmc+Cg==");
```
- [x] Added support for lines not starting with a property (multi-line var expressions)
- [x] Added support for lines terminating with a comma (multi-line var expressions)
```css
  --op-input-focus-primary: var(--op-input-inner-focus) var(--op-color-primary-plus-two),
    var(--op-input-outer-focus) var(--op-color-primary-plus-five);
```
