### PR TITLE
Add ActionCableHelper file and include it in helpers.rb and rspec_generator.rb

### DIFF
--- a/lib/generators/rolemodel/testing/rspec/rspec_generator.rb
+++ b/lib/generators/rolemodel/testing/rspec/rspec_generator.rb
@@ -26,6 +26,7 @@ module Rolemodel
         template 'support/capybara_drivers.rb', 'spec/support/capybara_drivers.rb'
         template 'support/capybara_testid.rb', 'spec/support/capybara_testid.rb'
         template 'support/helpers/test_element_helper.rb', 'spec/support/helpers/test_element_helper.rb'
+        template 'support/helpers/action_cable_helper.rb', 'spec/support/helpers/action_cable_helper.rb'
         template 'support/helpers.rb', 'spec/support/helpers.rb'
         template 'support/webpacker.rb', 'spec/support/webpacker.rb'
         append_file '.gitignore', 'spec/examples.txt'

--- a/lib/generators/rolemodel/testing/rspec/templates/support/helpers.rb
+++ b/lib/generators/rolemodel/testing/rspec/templates/support/helpers.rb
@@ -5,4 +5,5 @@ Dir[Rails.root.join('spec', 'support', 'helpers', '**', '*.rb')].each { |f| requ
 RSpec.configure do |c|
   # for example, given you have a spec/support/helpers/login_helpers.rb
   c.include TestElementHelper, type: :system
+  c.include ActionCableHelper, type: :system
 end

--- a/lib/generators/rolemodel/testing/rspec/templates/support/helpers/action_cable_helper.rb
+++ b/lib/generators/rolemodel/testing/rspec/templates/support/helpers/action_cable_helper.rb
@@ -1,0 +1,5 @@
+module ActionCableHelper
+  def wait_for_stream_connection
+    expect(page).to have_selector('turbo-cable-stream-source[connected]', visible: false)
+  end
+end


### PR DESCRIPTION
## Why?

With the launch of Turbo 8, capybara was having issues testing features that leverage action cable. This new helper forces capybara to delay its proceeding expectations until after the action cable connection has been established by the page.

## What Changed

* [X] Create action_cable_helper.rb
* [X] Include the helper in helpers.rb
* [X] Add the template reference to rspec_generator.rb