### PR TITLE
Rubocop settings to minimize churn

### DIFF
--- a/lib/generators/rolemodel/linters/rubocop/templates/.rubocop.yml
+++ b/lib/generators/rolemodel/linters/rubocop/templates/.rubocop.yml
@@ -31,11 +31,30 @@ Layout/ArrayAlignment:
 Layout:
   Severity: refactor
 
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/ArrayAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/DotPosition:
+  EnforcedStyle: leading
+
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/SpaceAroundOperators:
+  AllowForAlignment: false
+  EnforcedStyleForExponentOperator: no_space
 
 Lint/UnusedMethodArgument:
   Severity: refactor
@@ -64,3 +83,12 @@ Style:
 # It is ok to use inject at times
 Style/EachWithObject:
   Enabled: false
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma


### PR DESCRIPTION
## Why?
These rules reduce the number of lines highlighted by git as changed when new lines are added. See [this article](https://dev.to/epigene/the-raise-of-minimum-churn-style-in-ruby-3lj) for a full explanation.

## What Changed

What changed in this PR?

* [x] Add Layout and Style cops