### PR TITLE
Update webpack.config.js

### DIFF
--- a/lib/generators/rolemodel/webpack/templates/webpack.config.js
+++ b/lib/generators/rolemodel/webpack/templates/webpack.config.js
@@ -18,9 +18,6 @@ export default {
     application: [
       './app/javascript/application.js',
       './app/assets/stylesheets/application.scss'
-    ],
-    mailer: [
-      './app/assets/stylesheets/mailer.scss'
     ]
   },
   output: {


### PR DESCRIPTION
## Why?

Assuming a Mailer bundle when one does not exist causes asset compilation failure.

## What Changed

What changed in this PR?

* [x] drop mailer bundle from the default config