### PR TITLE
Update heroku_generator.rb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,25 @@
 PATH
   remote: .
   specs:
-    rolemodel_rails (0.7.1)
+    rolemodel_rails (0.8.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
     diff-lcs (1.5.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    parallel (1.26.2)
+    parser (3.3.4.2)
+      ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.0.6)
+    regexp_parser (2.9.2)
+    rexml (3.3.5)
+      strscan
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -21,6 +33,22 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.1)
+    rubocop (1.65.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.32.0)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    strscan (3.1.0)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   ruby
@@ -30,6 +58,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rolemodel_rails!
   rspec (~> 3.11)
+  rubocop
 
 BUNDLED WITH
    2.4.10

--- a/lib/generators/rolemodel/heroku/heroku_generator.rb
+++ b/lib/generators/rolemodel/heroku/heroku_generator.rb
@@ -30,17 +30,15 @@ module Rolemodel
     def create_assets_rake_tasks # rubocop:disable Metrics/MethodLength
       task_file = 'lib/tasks/assets.rake'
 
-      say '' # Add a newline
-      say 'In production, the node_modules folder can be removed after assets are compiled to significantly reduce slug size.', :yellow
-      say 'If your application depends on assets that are not bundled by Webpack, you may need the node_modules folder to remain.', :yellow
+      say 'Enhancing assets:precompile task to remove node_modules directory during production build.', :green
+      create_file task_file, <<~RAKE
+        # All runtime asset dependencies should be bundled by Webpack during asset precompilation.
+        # Therefore, the node_modules directory can be removed after assets are compiled to significantly reduce slug size.
+        # In rare cases, you may have a runtime dependency into node_modules directly. If this is the case and you are unable
+        # to bundle the dependency, delete this file and the node_modules directory will be included in your production slug.
 
-      if no?('Leave node_modules directory in production slug? (y/n)')
-        say '' # Add a newline
-        say 'Enhancing assets:precompile task to remove node_modules directory during production build.', :green
-        create_file task_file, <<~RAKE
-          Rake::Task['assets:precompile'].enhance { FileUtils.rm_rf(Rails.root.join('node_modules')) if Rails.env.production? }
-        RAKE
-      end
+        Rake::Task['assets:precompile'].enhance { FileUtils.rm_rf(Rails.root.join('node_modules')) if Rails.env.production? }
+      RAKE
     end
   end
 end

--- a/lib/generators/rolemodel/heroku/heroku_generator.rb
+++ b/lib/generators/rolemodel/heroku/heroku_generator.rb
@@ -37,7 +37,12 @@ module Rolemodel
         # In rare cases, you may have a runtime dependency into node_modules directly. If this is the case and you are unable
         # to bundle the dependency, delete this file and the node_modules directory will be included in your production slug.
 
-        Rake::Task['assets:precompile'].enhance { FileUtils.rm_rf(Rails.root.join('node_modules')) if Rails.env.production? }
+        Rake::Task['assets:precompile'].enhance do
+          if Rails.env.production?
+            Rails.logger.info 'Removing node_modules directory to reduce slug size.'
+            FileUtils.rm_rf(Rails.root.join('node_modules'))
+          end
+        end
       RAKE
     end
   end

--- a/lib/generators/rolemodel/heroku/heroku_generator.rb
+++ b/lib/generators/rolemodel/heroku/heroku_generator.rb
@@ -28,18 +28,18 @@ module Rolemodel
     end
 
     def create_assets_rake_tasks
-      say 'Enhance precompile task to remove heavy node_modules directory after build.', :green
+      say 'Add assets:minimize_footprint task to remove heavy node_modules directory after build.', :green
 
       create_file 'lib/tasks/assets.rake', <<~RAKE
         # frozen_string_literal: true
-        
+
         namespace :assets do
-          task cleanup: :environment do
-            puts 'Removing node_modules...'
+          desc 'Remove heavy node_modules directory when no longer needed.'
+          task minimize_footprint: :environment do
             FileUtils.rm_rf(Rails.root.join('node_modules'))
           end
         end
-        Rake::Task['assets:precompile'].enhance { Rake::Task['assets:cleanup'].invoke }
+        Rake::Task['assets:precompile'].enhance { Rake::Task['assets:cleanup'].invoke if Rails.env.production? }
       RAKE
     end
   end

--- a/lib/generators/rolemodel/heroku/heroku_generator.rb
+++ b/lib/generators/rolemodel/heroku/heroku_generator.rb
@@ -28,10 +28,8 @@ module Rolemodel
     end
 
     def create_assets_rake_tasks # rubocop:disable Metrics/MethodLength
-      task_file = 'lib/tasks/assets.rake'
-
       say 'Enhancing assets:precompile task to remove node_modules directory during production build.', :green
-      create_file task_file, <<~RAKE
+      rakefile('assets.rake', <<~RAKE)
         # All runtime asset dependencies should be bundled by Webpack during asset precompilation.
         # Therefore, the node_modules directory can be removed after assets are compiled to significantly reduce slug size.
         # In rare cases, you may have a runtime dependency into node_modules directly. If this is the case and you are unable

--- a/lib/generators/rolemodel/heroku/heroku_generator.rb
+++ b/lib/generators/rolemodel/heroku/heroku_generator.rb
@@ -39,7 +39,7 @@ module Rolemodel
 
         Rake::Task['assets:precompile'].enhance do
           if Rails.env.production?
-            Rails.logger.info 'Removing node_modules directory to reduce slug size.'
+            puts '----> Removing node_modules directory to reduce slug size.'
             FileUtils.rm_rf(Rails.root.join('node_modules'))
           end
         end

--- a/lib/generators/rolemodel/heroku/heroku_generator.rb
+++ b/lib/generators/rolemodel/heroku/heroku_generator.rb
@@ -30,25 +30,15 @@ module Rolemodel
     def create_assets_rake_tasks # rubocop:disable Metrics/MethodLength
       task_file = 'lib/tasks/assets.rake'
 
-      say 'Add assets:minimize_footprint task that removes the node_modules directory.', :green
-
-      create_file task_file, <<~RAKE
-        # frozen_string_literal: true
-
-        namespace :assets do
-          task minimize_footprint: :environment do
-            FileUtils.rm_rf(Rails.root.join('node_modules'))
-          end
-        end
-      RAKE
-
       say '' # Add a newline
-      say 'In production, assets:minimize_footprint can be run right after assets:precompile to significantly reduce slug size.', :yellow
-      say 'If your application requires an asset that is not bundled by Webpack, you may need the node_modules folder to remain.', :yellow
+      say 'In production, the node_modules folder can be removed after assets are compiled to significantly reduce slug size.', :yellow
+      say 'If your application depends on assets that are not bundled by Webpack, you may need the node_modules folder to remain.', :yellow
 
       if no?('Leave node_modules directory in production slug? (y/n)')
-        append_to_file task_file, <<~RAKE
-          Rake::Task['assets:precompile'].enhance { Rake::Task['assets:cleanup'].invoke if Rails.env.production? }
+        say '' # Add a newline
+        say 'Enhancing assets:precompile task to remove node_modules directory during production build.', :green
+        create_file task_file, <<~RAKE
+          Rake::Task['assets:precompile'].enhance { FileUtils.rm_rf(Rails.root.join('node_modules')) if Rails.env.production? }
         RAKE
       end
     end

--- a/lib/generators/rolemodel/heroku/heroku_generator.rb
+++ b/lib/generators/rolemodel/heroku/heroku_generator.rb
@@ -36,7 +36,6 @@ module Rolemodel
         # frozen_string_literal: true
 
         namespace :assets do
-          desc 'Remove heavy node_modules directory when no longer needed.'
           task minimize_footprint: :environment do
             FileUtils.rm_rf(Rails.root.join('node_modules'))
           end

--- a/lib/generators/rolemodel/heroku/heroku_generator.rb
+++ b/lib/generators/rolemodel/heroku/heroku_generator.rb
@@ -3,20 +3,44 @@ module Rolemodel
     source_root File.expand_path('templates', __dir__)
 
     def install_app_json
+      say 'Install app.json file', :green
+
       @project_name = Rails.application.class.try(:parent_name) || Rails.application.class.module_parent_name
       template 'app.json.erb', 'app.json'
     end
 
     def install_procfile
+      say 'Install Procfile', :green
+
       template 'Procfile'
     end
 
     def force_ssl
+      say 'Require SSL for production environment.', :green
+
       uncomment_lines('config/environments/production.rb', 'config.force_ssl = true')
     end
 
     def enable_log_level_configurability
+      say 'Enable log-level adjustment via "LOG_LEVEL" environment variable', :green
+
       gsub_file('config/environments/production.rb', 'config.log_level = :info', "config.log_level = ENV.fetch('LOG_LEVEL', 'INFO')")
+    end
+
+    def create_assets_rake_tasks
+      say 'Enhance precompile task to remove heavy node_modules directory after build.', :green
+
+      create_file 'lib/tasks/assets.rake', <<~RAKE
+        # frozen_string_literal: true
+        
+        namespace :assets do
+          task cleanup: :environment do
+            puts 'Removing node_modules...'
+            FileUtils.rm_rf(Rails.root.join('node_modules'))
+          end
+        end
+        Rake::Task['assets:precompile'].enhance { Rake::Task['assets:cleanup'].invoke }
+      RAKE
     end
   end
 end

--- a/rolemodel_rails.gemspec
+++ b/rolemodel_rails.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.11"
+  spec.add_development_dependency "rubocop"
 end


### PR DESCRIPTION
## Why?

Add user feedback to existing generator step methods and add an additional step that adds a `assets:cleanup` task.  As well as enhancing the `assets:precompile` task to cleanup afterwards.

In collaboration with @mikehale

<img width="749" alt="Screenshot 2024-08-15 at 11 42 53 AM" src="https://github.com/user-attachments/assets/f228ec2c-f03a-408f-9fcf-8a0ed519052b">

<img width="821" alt="Screenshot 2024-08-15 at 11 39 51 AM" src="https://github.com/user-attachments/assets/75408a80-5144-4a38-98e1-0ac2ef81970c">

