### PR TITLE
toggle controller inert attribute

### DIFF
--- a/lib/generators/rolemodel/modals/templates/app/javascript/controllers/toggle_controller.js
+++ b/lib/generators/rolemodel/modals/templates/app/javascript/controllers/toggle_controller.js
@@ -7,6 +7,10 @@ export default class extends Controller {
     performOnConnect: {
       type: Boolean,
       default: false,
+    },
+    performToggleInert: {
+      type: Boolean,
+      default: false
     }
   }
 
@@ -40,6 +44,12 @@ export default class extends Controller {
 
   _toggleActiveClass(element, direction = !element.classList.contains(this.activeClass)) {
     // next-tick to allow animation-in after connect
-    setTimeout(()=>{element.classList.toggle(this.activeClass, direction)}, 0)
+    setTimeout(()=>{
+      element.classList.toggle(this.activeClass, direction)
+
+      if (this.performToggleInertValue) {
+        element.inert = !direction
+      }
+    }, 0)
   }
 }

--- a/lib/generators/rolemodel/modals/templates/app/views/layouts/modal.html.slim.tt
+++ b/lib/generators/rolemodel/modals/templates/app/views/layouts/modal.html.slim.tt
@@ -12,6 +12,7 @@ html
         class=class_names('modal-wrapper--active' => response.message == 'Unprocessable Entity')
         data-controller="toggle"
         data-toggle-perform-on-connect-value=(response.message == 'OK')
+        data-toggle-perform-toggle-inert-value
         data-toggle-active-class="modal-wrapper--active"
         data-turbo-cache="false"
         data-action="keydown.esc@window->toggle#off"

--- a/lib/generators/rolemodel/modals/templates/app/views/layouts/panel.html.slim.tt
+++ b/lib/generators/rolemodel/modals/templates/app/views/layouts/panel.html.slim.tt
@@ -13,6 +13,7 @@ html
         class=class_names('panel--active' => response.message == 'Unprocessable Entity')
         data-controller="toggle"
         data-toggle-perform-on-connect-value=(response.message == 'OK')
+        data-toggle-perform-toggle-inert-value
         data-toggle-active-class="panel--active"
         data-turbo-cache="false"
       )

--- a/spec/generators/rolemodel/modals_generator_spec.rb
+++ b/spec/generators/rolemodel/modals_generator_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'generators/rolemodel/modals/modals_generator'
+
+RSpec.describe Rolemodel::ModalsGenerator, type: :generator do
+  destination File.expand_path('tmp/', File.dirname(__FILE__))
+
+  before { run_generator_against_test_app }
+
+  it 'installs Turbo Confirm package' do
+    assert_file 'yarn.lock' do |content|
+      expect(content).to include('@rolemodel/turbo-confirm')
+    end
+  end
+
+  it 'generates views & link helpers' do
+    assert_file 'app/helpers/turbo_frame_link_helper.rb'
+    assert_file 'app/views/layouts/modal.html.slim'
+    assert_file 'app/views/layouts/panel.html.slim'
+    assert_file 'app/views/application/_confirm.html.slim'
+  end
+
+  it 'generates & imports javascript files' do
+    assert_file 'app/javascript/controllers/toggle_controller.js'
+    assert_file 'app/javascript/initializers/turbo_confirm.js'
+    assert_file 'app/javascript/initializers/frame_missing_handler.js'
+
+    assert_file 'app/javascript/application.js' do |content|
+      expect(content).to include("import './initializers/turbo_confirm'")
+      expect(content).to include("import './initializers/frame_missing_handler'")
+    end
+  end
+end


### PR DESCRIPTION
## Why?

Remote content is still included in the tab index, even if off screen and not scrollable into view. This is relevant when modal or panels are dismissed but still have contents within them. This change allows the [inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert) data attribute to be toggle along with the active class. This makes the contents non interactive. This makes them both more usable and more accessible.

## What Changed

What changed in this PR?

* [X] Add option to toggle inert attribute when toggling panel and modals
* [X] Add test for the generator

## Screenshots

https://github.com/user-attachments/assets/dc5d068e-7ba2-4e04-b673-93ade9e91153
