### PR TITLE
Make modal compatible with Rack 3.1

### DIFF
--- a/lib/generators/rolemodel/modals/templates/app/views/layouts/panel.html.slim.tt
+++ b/lib/generators/rolemodel/modals/templates/app/views/layouts/panel.html.slim.tt
@@ -10,7 +10,7 @@ html
     = turbo_frame_tag 'panel' do
       .panel.flex.items-center.justify-center(
         data-testid='panel'
-        class=class_names('panel--active' => response.message == 'Unprocessable Entity')
+        class=class_names('panel--active' => response.message == 'Unprocessable Content' || response.message == 'Unprocessable Entity')
         data-controller="toggle"
         data-toggle-perform-on-connect-value=(response.message == 'OK')
         data-toggle-active-class="panel--active"


### PR DESCRIPTION
## Task

See https://rolemodelsoftware.slack.com/archives/C051DL755/p1730914751683569?thread_ts=1718918599.340109&cid=C051DL755

## Why?

See https://github.com/rack/rack/pull/2137
## What Changed

What changed in this PR?

* [x] Allow for Rack 3.1 422 response messages with "Unprocessable Content"
