### PR TITLE
Update Github pull_request_template.md to include README update, remove Task section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,3 @@
-## Task
-
-[TR #XXX]()
-
 ## Why?
 
 Why were the changes needed? What issues were the changes addressing?
@@ -14,6 +10,10 @@ What changed in this PR?
 * [ ] Change 1
 * [ ] Change 2
 * [ ] ...
+
+## Pre-merge checklist
+
+* [ ] Update relevant READMEs
 
 ## Screenshots
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,13 +7,12 @@ Why were the changes needed? What issues were the changes addressing?
 
 What changed in this PR?
 
-* [ ] Change 1
-* [ ] Change 2
-* [ ] ...
+* [ ] Change1
 
 ## Pre-merge checklist
 
 * [ ] Update relevant READMEs
+* [ ] Update version number in `lib/rolemodel_rails/version.rb`
 
 ## Screenshots
 

--- a/lib/generators/rolemodel/github/templates/pull_request_template.md
+++ b/lib/generators/rolemodel/github/templates/pull_request_template.md
@@ -1,7 +1,3 @@
-## Task
-
-[TR #XXX]()
-
 ## Why?
 
 Why were the changes needed? What issues were the changes addressing?
@@ -14,6 +10,10 @@ What changed in this PR?
 * [ ] Change 1
 * [ ] Change 2
 * [ ] ...
+
+## Pre-merge checklist
+
+* [ ] Update relevant READMEs
 
 ## Screenshots
 

--- a/lib/generators/rolemodel/github/templates/pull_request_template.md
+++ b/lib/generators/rolemodel/github/templates/pull_request_template.md
@@ -7,9 +7,7 @@ Why were the changes needed? What issues were the changes addressing?
 
 What changed in this PR?
 
-* [ ] Change 1
-* [ ] Change 2
-* [ ] ...
+* [ ] Change1
 
 ## Pre-merge checklist
 


### PR DESCRIPTION
## Why?

Why were the changes needed? What issues were the changes addressing?
(Note: some changes may seem unrelated to the ticket, this is a great place to explain further.)

Linear automatically links to the PR when referenced in the PR name; READMEs are hard to remember to update to confirm they get updated upon PR creation/review

## What Changed

What changed in this PR?

* [x] remove Task reference from pull_request_template generator
* [x] add README update pre-merge checklist to pull_request_template generator
* [x] add/remove from rolemodel_rails pull_request_template.md too
* [x] remove extra checklist items
* [x] add checklist item for updating rolemodel_rails version

## Screenshots

If any UI changes need to be shown off, please add screenshots here.
