### PR TITLE
fix controller logging, always use lograge

### DIFF
--- a/lib/generators/rolemodel/lograge/templates/config/initializers/lograge.rb
+++ b/lib/generators/rolemodel/lograge/templates/config/initializers/lograge.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-if %w[development test].exclude?(Rails.env)
-  Rails.application.configure do
-    config.lograge.enabled = true
-    config.lograge.custom_options = lambda do |event|
-      exceptions = %w[controller action format id]
-      {
-        params: event.payload[:params].except(*exceptions),
-        # user_id: controller.current_user.try(:id)
-      }
-    end
+Rails.application.configure do
+  config.lograge.enabled = true
+  config.lograge.custom_payload do |controller|
+    {
+      user_id: controller.current_user.try(:id)
+    }
+  end
+  config.lograge.custom_options = lambda do |event|
+    exceptions = %w[controller action format id]
+    {
+      params: event.payload[:params].except(*exceptions)
+    }
   end
 end


### PR DESCRIPTION
## Why?

The previous configuration was broken because the controller was not available in the context

## What Changed

What changed in this PR?

* [x] Update config to fix controller reference
* [x] Enable lograge in all environments

## Pre-merge checklist

* [ ] Update relevant READMEs
* [ ] Update version number in `lib/rolemodel_rails/version.rb`

## Screenshots

If any UI changes need to be shown off, please add screenshots here.
