### PR TITLE
Unmount React Components That Get Removed From the DOM

### DIFF
--- a/lib/generators/rolemodel/react/templates/app/javascript/controllers/react_controller.js
+++ b/lib/generators/rolemodel/react/templates/app/javascript/controllers/react_controller.js
@@ -21,4 +21,8 @@ export default class extends Controller {
       throw new Error('Unrecognized React component name!')
     }
   }
+
+  disconnect() {
+    ReactDOM.unmountComponentAtNode(this.element)
+  }
 }

--- a/lib/rolemodel_rails/version.rb
+++ b/lib/rolemodel_rails/version.rb
@@ -1,3 +1,3 @@
 module RolemodelRails
-  VERSION = '0.12.0'
+  VERSION = '0.12.1'
 end

--- a/lib/rolemodel_rails/version.rb
+++ b/lib/rolemodel_rails/version.rb
@@ -1,3 +1,3 @@
 module RolemodelRails
-  VERSION = '0.12.1'
+  VERSION = '0.12.0'
 end


### PR DESCRIPTION
## Why?

When a component is mounted using the `react_controller` and the DOM element it is attached to gets removed, the component doesn't actually get unmounted

## What Changed

* [x] Add a `dismount` method to react controller that unmounts react components

## Pre-merge checklist

* [x] Update relevant READMEs
* [ ] Update version number in `lib/rolemodel_rails/version.rb`
