### PR TITLE
Improve source map generator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rolemodel_rails (0.13.0)
+    rolemodel_rails (0.14.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/generators/rolemodel/source_map/README.md
+++ b/lib/generators/rolemodel/source_map/README.md
@@ -10,4 +10,4 @@ Adds Rack middleware for serving js source maps only to allowed users in a produ
 ## Usage
 
 * Ensure that app uses Warden::Manager middleware
-* Set ENV['SOURCE_MAPS_ALLOWED_USERS_EMAILS'] to a space separated list of emails or update the middleware to allow all super admins
+* Set ENV['SOURCE_MAPS_ALLOWED_USERS_EMAILS'] to a comma-separated list of emails or update the middleware to allow all super admins

--- a/lib/generators/rolemodel/source_map/README.md
+++ b/lib/generators/rolemodel/source_map/README.md
@@ -3,14 +3,11 @@
 ## What you get
 
 * Rack middleware for serving source maps
+* Enhanced assets rake tasks to relocate and manage source map files
 
 Adds Rack middleware for serving js source maps only to allowed users in a production environment.
 
 ## Usage
-    
+
 * Ensure that app uses Warden::Manager middleware
-* Set ENV['SOURCE_MAPS_ALLOWED_USERS_EMAILS'] to a space separated list of emails
-* Next configs must be applied to a bundling tool (e.g. Webpack):
-    * [bundle].js needs to be placed in [RAILS_ROOT]/public/packs/js directory
-    * Generate  source maps and append sourceMappingURL=[bundle].js bundled file
-    * Relocate source maps out of [RAILS_ROOT]/public/packs/js/ directory to the [RAILS_ROOT]/maps/js directory
+* Set ENV['SOURCE_MAPS_ALLOWED_USERS_EMAILS'] to a space separated list of emails or update the middleware to allow all super admins

--- a/lib/generators/rolemodel/source_map/USAGE
+++ b/lib/generators/rolemodel/source_map/USAGE
@@ -5,4 +5,5 @@ Example:
     rails generate rolemodel:source_map
 
     This will create:
-        app/middleware/rolemodel/source_map.rb
+        lib/middleware/rolemodel/source_map.rb
+        lib/tasks/assets.rake

--- a/lib/generators/rolemodel/source_map/source_map_generator.rb
+++ b/lib/generators/rolemodel/source_map/source_map_generator.rb
@@ -5,8 +5,8 @@ module Rolemodel
     source_root File.expand_path('templates', __dir__)
 
     def inject_config_for_production
-      inject_into_file 'config/environments/production.rb', "\nrequire_relative Rails.root.join('lib/middleware/rolemodel/source_map.rb')\n", after: "# frozen_string_literal: true\n"
-      inject_into_file 'config/environments/production.rb', "\nconfig.middleware.insert_after Warden::Manager, Rolemodel::SourceMap\n\n", after: "Rails.application.configure do\n"
+      inject_into_file 'config/environments/production.rb', "\nrequire_relative Rails.root.join('lib/middleware/rolemodel/source_map.rb')\n", after: "require \"active_support/core_ext/integer/time\"\n"
+      inject_into_file 'config/environments/production.rb', "\n  config.middleware.insert_after Warden::Manager, Rolemodel::SourceMap\n\n", after: "Rails.application.configure do\n"
     end
 
     def copy_middleware_files

--- a/lib/generators/rolemodel/source_map/source_map_generator.rb
+++ b/lib/generators/rolemodel/source_map/source_map_generator.rb
@@ -13,7 +13,7 @@ module Rolemodel
       copy_file 'lib/middleware/rolemodel/source_map.rb'
     end
 
-    def copy_assetes_rake_task
+    def copy_assets_rake_task
       copy_file 'lib/tasks/assets.rake'
     end
   end

--- a/lib/generators/rolemodel/source_map/source_map_generator.rb
+++ b/lib/generators/rolemodel/source_map/source_map_generator.rb
@@ -6,11 +6,15 @@ module Rolemodel
 
     def inject_config_for_production
       inject_into_file 'config/environments/production.rb', "\nrequire_relative Rails.root.join('lib/middleware/rolemodel/source_map.rb')\n", after: "# frozen_string_literal: true\n"
-      inject_into_file 'config/environments/production.rb', "\nconfig.middleware.use  Rolemodel::SourceMap\n\n", after: "Rails.application.configure do\n"
+      inject_into_file 'config/environments/production.rb', "\nconfig.middleware.insert_after Warden::Manager, Rolemodel::SourceMap\n\n", after: "Rails.application.configure do\n"
     end
 
     def copy_middleware_files
       copy_file 'lib/middleware/rolemodel/source_map.rb'
+    end
+
+    def copy_assetes_rake_task
+      copy_file 'lib/tasks/assets.rake'
     end
   end
 end

--- a/lib/generators/rolemodel/source_map/templates/lib/middleware/rolemodel/source_map.rb
+++ b/lib/generators/rolemodel/source_map/templates/lib/middleware/rolemodel/source_map.rb
@@ -7,22 +7,33 @@ module Rolemodel
       default_headers = {'Set-Cookie' => 'Same-Site=None', 'Cache-Control' => 'max-age=0;no-cache'}
       custom_headers = default_headers.merge(options.delete(:headers) || {})
       @app = app
-      @allowed_users_emails = ENV['SOURCE_MAPS_ALLOWED_USERS_EMAILS'] || nil
+      @allowed_users_emails = ENV.fetch('SOURCE_MAPS_ALLOWED_USERS_EMAILS', '').split(',')
       @file_server = Rack::Files.new(root, custom_headers)
     end
 
     def call(env)
-      serve?(env) ? @file_server.call(env.tap { |env| env['PATH_INFO'].sub!(/^\/[\w-]+[^\/]/, '') }) : @app.call(env)
+      if allowed_sourcemap?(env)
+        @file_server.call(env.tap { |env| env['PATH_INFO'].sub!(/^\/[\w-]+[^\/]/, '') })
+      else
+        @app.call(env)
+      end
     end
 
     private
 
-    def serve?(env)
-      ENV['RAILS_ENV'] == 'production' && env['PATH_INFO'].match?(/\.map\z/) && permit_user?(env)
+    def allowed_sourcemap?(env)
+      return false unless env['PATH_INFO'].end_with?('.map')
+
+      permit_user?(env)
     end
 
     def permit_user?(env)
-      (current_user_email = current_user(env)&.email)&.empty? && @allowed_users_emails&.include?(current_user_email)
+      # Alternatively, allow sourcemaps for all super admins
+      # current_user(env)&.super_admin?
+      current_user_email = current_user(env)&.email
+      return false if current_user_email.blank?
+
+      @allowed_users_emails.include?(current_user_email)
     end
 
     def current_user(env)

--- a/lib/generators/rolemodel/source_map/templates/lib/tasks/assets.rake
+++ b/lib/generators/rolemodel/source_map/templates/lib/tasks/assets.rake
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+namespace :assets do
+  task clean_sourcemaps: :environment do
+    maps_root = Rails.root.join('maps')
+    next unless maps_root.exist?
+
+    assets_root = Rails.public_path.join('assets')
+
+    puts 'Cleaning sourcemaps folder'
+    maps_root.glob('*.map').each do |map_file|
+      asset_file = map_file.basename('.map')
+      map_file.delete unless assets_root.join(asset_file).exist?
+    end
+  end
+
+  task relocate_sourcemaps: :environment do
+    maps_root = Rails.root.join('maps')
+    maps_root.mkpath
+
+    puts 'Relocating sourcemap files'
+    Rails.root.glob('public/assets/*.map').each do |map_file|
+      map_file.rename(maps_root.join(map_file.basename))
+    end
+  end
+
+  task clear_sourcemaps: :environment do
+    maps_root = Rails.root.join('maps')
+    maps_root.rmtree if maps_root.exist?
+  end
+end
+
+Rake::Task['assets:clean'].enhance do
+  Rake::Task['assets:clean_sourcemaps'].invoke
+end
+
+Rake::Task['assets:precompile'].enhance do
+  Rake::Task['assets:relocate_sourcemaps'].invoke
+end
+
+Rake::Task['assets:clobber'].enhance do
+  Rake::Task['assets:clear_sourcemaps'].invoke
+end

--- a/lib/rolemodel_rails/version.rb
+++ b/lib/rolemodel_rails/version.rb
@@ -1,3 +1,3 @@
 module RolemodelRails
-  VERSION = '0.13.0'
+  VERSION = '0.14.0'
 end

--- a/spec/generators/rolemodel/source_map_generator_spec.rb
+++ b/spec/generators/rolemodel/source_map_generator_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'generators/rolemodel/source_map/source_map_generator'
+
+RSpec.describe Rolemodel::SourceMapGenerator, type: :generator do
+  destination File.expand_path('tmp/', File.dirname(__FILE__))
+
+  before { run_generator_against_test_app }
+
+  it 'enhances assets rake tasks to manage sourcemaps' do
+    assert_file 'lib/tasks/assets.rake'
+  end
+
+  it 'adds a middleware to control access to sourcemaps' do
+    assert_file 'lib/middleware/rolemodel/source_map.rb'
+    assert_file 'config/environments/production.rb' do |content|
+      expect(content).to include("require_relative Rails.root.join('lib/middleware/rolemodel/source_map.rb')")
+      expect(content).to include('config.middleware.insert_after Warden::Manager, Rolemodel::SourceMap')
+    end
+  end
+end


### PR DESCRIPTION
## Why?

The recommended approach to relocating source maps breaks under Propshaft, because Propshaft removes source map URLs if it can't find the source map files. Instead of relying on the build (webpack) to relocate source maps, this takes the approach of enhancing the Rails assets rake tasks to manage source map files.

## What Changed

What changed in this PR?

* [x] Add rake tasks to enhance assets:precompile, assets:clean, and assets:clobber
* [x] Clean up source map middleware and add suggestion for alternate auth check
* [x] Adjust insertions to config/environments/production.rb
* [x] Add a test for the source map generator

## Pre-merge checklist

* [x] Update relevant READMEs
* [x] Update version number in `lib/rolemodel_rails/version.rb`