### PR TITLE
Add no_chrome_tag to rubocop generator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rolemodel_rails (0.15.0)
+    rolemodel_rails (0.16.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,11 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.32.0)
       parser (>= 3.3.1.0)
+    rubocop-rails (2.29.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.52.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.3.1)
     stringio (3.1.1)
@@ -154,6 +159,7 @@ DEPENDENCIES
   rspec (~> 3.11)
   rspec_junit_formatter
   rubocop
+  rubocop-rails
 
 BUNDLED WITH
    2.4.10

--- a/lib/generators/rolemodel/linters/rubocop/README.md
+++ b/lib/generators/rolemodel/linters/rubocop/README.md
@@ -4,3 +4,4 @@
 
 A Rubocop installation with a standard .rubocop.yml config.
 A custom cop that ensures form validation error responses use the correct status of `422 Unprocessable Entity`.
+A custom cop that ensures the :chrome tag does not exist in specs.

--- a/lib/generators/rolemodel/linters/rubocop/rubocop_generator.rb
+++ b/lib/generators/rolemodel/linters/rubocop/rubocop_generator.rb
@@ -20,6 +20,7 @@ module Rolemodel
       def add_config
         copy_file '.rubocop.yml'
         copy_file 'lib/cops/form_error_response.rb'
+        copy_file 'lib/cops/no_chrome_tag.rb'
       end
     end
   end

--- a/lib/generators/rolemodel/linters/rubocop/templates/.rubocop.yml
+++ b/lib/generators/rolemodel/linters/rubocop/templates/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rails
   - ./lib/cops/form_error_response.rb
+  - ./lib/cops/no_chrome_tag.rb
 
 AllCops:
   Exclude:

--- a/lib/generators/rolemodel/linters/rubocop/templates/.rubocop.yml
+++ b/lib/generators/rolemodel/linters/rubocop/templates/.rubocop.yml
@@ -1,7 +1,8 @@
 require:
-  - rubocop-rails
   - ./lib/cops/form_error_response.rb
   - ./lib/cops/no_chrome_tag.rb
+plugins:
+  - rubocop-rails
 
 AllCops:
   Exclude:

--- a/lib/generators/rolemodel/linters/rubocop/templates/lib/cops/form_error_response.rb
+++ b/lib/generators/rolemodel/linters/rubocop/templates/lib/cops/form_error_response.rb
@@ -13,25 +13,27 @@
 # This checks the specific matching line to ensure it meets our expectations
 
 # Custom Cop to Ensure Form Error Response Statuses
-class FormErrorResponse < RuboCop::Cop::Base
-  # Match code in the else branch that either: is the only line and looks like `render :something, ...`
-  # or is not the first line and looks like the same.
-  def_node_matcher :form_error, <<~PATTERN
-    {(... $(send nil? :render (:sym _) ...)) | $(send nil? :render (:sym _) ...)}
-  PATTERN
+module Cops
+  class FormErrorResponse < RuboCop::Cop::Base
+    # Match code in the else branch that either: is the only line and looks like `render :something, ...`
+    # or is not the first line and looks like the same.
+    def_node_matcher :form_error, <<~PATTERN
+      {(... $(send nil? :render (:sym _) ...)) | $(send nil? :render (:sym _) ...)}
+    PATTERN
 
-  MSG = 'Use status: :unprocessable_entity for invalid form requests.'
+    MSG = 'Use status: :unprocessable_entity for invalid form requests.'
 
-  # Ensure the render is returning a status of unprocessable entity,
-  # otherwise add the offense
-  STATUS_PAIR = /\(pair\s+\(sym :status\)\s+\(sym :unprocessable_entity\)\)/m
+    # Ensure the render is returning a status of unprocessable entity,
+    # otherwise add the offense
+    STATUS_PAIR = /\(pair\s+\(sym :status\)\s+\(sym :unprocessable_entity\)\)/m
 
-  # Only check within if blocks
-  def on_if(node)
-    form_error(node.else_branch) do |name|
-      next if name.to_s.match?(STATUS_PAIR)
+    # Only check within if blocks
+    def on_if(node)
+      form_error(node.else_branch) do |name|
+        next if name.to_s.match?(STATUS_PAIR)
 
-      add_offense(name)
+        add_offense(name)
+      end
     end
   end
 end

--- a/lib/generators/rolemodel/linters/rubocop/templates/lib/cops/form_error_response.rb
+++ b/lib/generators/rolemodel/linters/rubocop/templates/lib/cops/form_error_response.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-# There are three levels of matching here:
-# Methods (def on_if)
-# This scans code and only stops on the method specified.
-# E.G. `on_if` will only move into the below checks when it encounters an if statement.
-
-# Node matcher (def_node_matcher :form_error)
-# This scans the block of code (in this case, the else branch of the if block)
-# using AST (Abstract Tree Syntax) to match certain patterns
-
-# Regex
-# This checks the specific matching line to ensure it meets our expectations
-
-# Custom Cop to Ensure Form Error Response Statuses
 module Cops
+  # Custom Cop to Ensure Form Error Response Statuses
+  #
+  # There are three levels of matching here:
+  # Methods (def on_if)
+  # This scans code and only stops on the method specified.
+  # E.G. `on_if` will only move into the below checks when it encounters an if statement.
+  #
+  # Node matcher (def_node_matcher :form_error)
+  # This scans the block of code (in this case, the else branch of the if block)
+  # using AST (Abstract Tree Syntax) to match certain patterns
+  #
+  # Regex
+  # This checks the specific matching line to ensure it meets our expectations
   class FormErrorResponse < RuboCop::Cop::Base
     # Match code in the else branch that either: is the only line and looks like `render :something, ...`
     # or is not the first line and looks like the same.

--- a/lib/generators/rolemodel/linters/rubocop/templates/lib/cops/form_error_response.rb
+++ b/lib/generators/rolemodel/linters/rubocop/templates/lib/cops/form_error_response.rb
@@ -15,6 +15,8 @@ module Cops
   # Regex
   # This checks the specific matching line to ensure it meets our expectations
   class FormErrorResponse < RuboCop::Cop::Base
+    extend RuboCop::Cop::AutoCorrector
+
     # Match code in the else branch that either: is the only line and looks like `render :something, ...`
     # or is not the first line and looks like the same.
     def_node_matcher :form_error, <<~PATTERN
@@ -32,7 +34,9 @@ module Cops
       form_error(node.else_branch) do |name|
         next if name.to_s.match?(STATUS_PAIR)
 
-        add_offense(name)
+        add_offense(name) do |corrector|
+          corrector.insert_after(name, ', status: :unprocessable_entity')
+        end
       end
     end
   end

--- a/lib/generators/rolemodel/linters/rubocop/templates/lib/cops/no_chrome_tag.rb
+++ b/lib/generators/rolemodel/linters/rubocop/templates/lib/cops/no_chrome_tag.rb
@@ -2,41 +2,43 @@
 
 require 'rubocop'
 
-class NoChromeTag < RuboCop::Cop::Base
-  include RangeHelp
-  extend AutoCorrector
+module Cops
+  class NoChromeTag < RuboCop::Cop::Base
+    include RuboCop::Cop::RangeHelp
+    extend RuboCop::Cop::AutoCorrector
 
-  MSG = 'The :chrome tag is only for testing, and should not be checked into the repository.'
-  RESTRICT_ON_SEND = [:describe, :context, :it, :feature, :scenario].freeze
+    MSG = 'The :chrome tag is only for testing, and should not be checked into the repository.'
+    RESTRICT_ON_SEND = %i[describe context it feature scenario].freeze
 
-  def on_send(node)
-    node.arguments.each do |a|
-      if a.sym_type? && a.value == :chrome
-        range = range_with_surrounding_comma(a.source_range)
-        add_offense(range) do |corrector|
-          corrector.replace(range, '')
+    def on_send(node)
+      node.arguments.each do |a|
+        if a.sym_type? && a.value == :chrome
+          range = range_with_surrounding_comma(a.source_range)
+          add_offense(range) do |corrector|
+            corrector.replace(range, '')
+          end
         end
-      end
 
-      next unless a.hash_type?
+        next unless a.hash_type?
 
-      a.pairs.each do |pair|
-        next unless pair.key.value == :chrome
+        a.pairs.each do |pair|
+          next unless pair.key.value == :chrome
 
-        range = range_with_surrounding_comma(pair.source_range)
-        add_offense(range) do |corrector|
-          corrector.replace(range, '')
+          range = range_with_surrounding_comma(pair.source_range)
+          add_offense(range) do |corrector|
+            corrector.replace(range, '')
+          end
         end
       end
     end
-  end
 
-  def range_with_surrounding_comma(source_range)
-    buffer = source_range.source_buffer
-    src = buffer.source
-    end_pos = source_range.end_pos
-    comma_index = src[...end_pos].rindex(/\s*,\s*/)
+    def range_with_surrounding_comma(source_range)
+      buffer = source_range.source_buffer
+      src = buffer.source
+      end_pos = source_range.end_pos
+      comma_index = src[...end_pos].rindex(/\s*,\s*/)
 
-    Parser::Source::Range.new(buffer, comma_index, end_pos)
+      Parser::Source::Range.new(buffer, comma_index, end_pos)
+    end
   end
 end

--- a/lib/generators/rolemodel/linters/rubocop/templates/lib/cops/no_chrome_tag.rb
+++ b/lib/generators/rolemodel/linters/rubocop/templates/lib/cops/no_chrome_tag.rb
@@ -3,6 +3,7 @@
 require 'rubocop'
 
 module Cops
+  # Detect occurences of the chrome tag in specs, and warn and remove them.
   class NoChromeTag < RuboCop::Cop::Base
     include RuboCop::Cop::RangeHelp
     extend RuboCop::Cop::AutoCorrector
@@ -10,7 +11,7 @@ module Cops
     MSG = 'The :chrome tag is only for testing, and should not be checked into the repository.'
     RESTRICT_ON_SEND = %i[describe context it feature scenario].freeze
 
-    def on_send(node)
+    def on_send(node) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       node.arguments.each do |a|
         if a.sym_type? && a.value == :chrome
           range = range_with_surrounding_comma(a.source_range)

--- a/lib/generators/rolemodel/linters/rubocop/templates/lib/cops/no_chrome_tag.rb
+++ b/lib/generators/rolemodel/linters/rubocop/templates/lib/cops/no_chrome_tag.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+class NoChromeTag < RuboCop::Cop::Base
+  include RangeHelp
+  extend AutoCorrector
+
+  MSG = 'The :chrome tag is only for testing, and should not be checked into the repository.'
+  RESTRICT_ON_SEND = [:describe, :context, :it, :feature, :scenario].freeze
+
+  def on_send(node)
+    node.arguments.each do |a|
+      if a.sym_type? && a.value == :chrome
+        range = range_with_surrounding_comma(a.source_range)
+        add_offense(range) do |corrector|
+          corrector.replace(range, '')
+        end
+      end
+
+      next unless a.hash_type?
+
+      a.pairs.each do |pair|
+        next unless pair.key.value == :chrome
+
+        range = range_with_surrounding_comma(pair.source_range)
+        add_offense(range) do |corrector|
+          corrector.replace(range, '')
+        end
+      end
+    end
+  end
+
+  def range_with_surrounding_comma(source_range)
+    buffer = source_range.source_buffer
+    src = buffer.source
+    end_pos = source_range.end_pos
+    comma_index = src[...end_pos].rindex(/\s*,\s*/)
+
+    Parser::Source::Range.new(buffer, comma_index, end_pos)
+  end
+end

--- a/lib/rolemodel_rails/version.rb
+++ b/lib/rolemodel_rails/version.rb
@@ -1,3 +1,3 @@
 module RolemodelRails
-  VERSION = '0.15.0'
+  VERSION = '0.16.0'.freeze
 end

--- a/rolemodel_rails.gemspec
+++ b/rolemodel_rails.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "generator_spec", "~> 0.10"
   spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop-rails"
 end

--- a/spec/cops/form_error_response_spec.rb
+++ b/spec/cops/form_error_response_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'rubocop'
+require 'rubocop/rspec/support'
+require 'generators/rolemodel/linters/rubocop/templates/lib/cops/form_error_response'
+
+RSpec.describe Cops::FormErrorResponse, :config do
+  include RuboCop::RSpec::ExpectOffense
+
+  it 'registers an offense when :unprocessable_entity is absent' do
+    expect_offense(<<~RUBY)
+      if false
+        # redirect_to
+      else
+        render :new
+        ^^^^^^^^^^^ Use status: :unprocessable_entity for invalid form requests.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when :unprocessable_entity is present' do
+    expect_no_offenses(<<~RUBY)
+      if false
+        # redirect_to
+      else
+        render :new, status: :unprocessable_entity
+      end
+    RUBY
+  end
+end

--- a/spec/cops/form_error_response_spec.rb
+++ b/spec/cops/form_error_response_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Cops::FormErrorResponse, :config do
 
   it 'registers an offense when :unprocessable_entity is absent' do
     expect_offense(<<~RUBY)
-      if false
-        # redirect_to
+      if @user.save
+        redirect_to users_url, notice: notice_msg('User successfully updated')
       else
         render :new
         ^^^^^^^^^^^ Use status: :unprocessable_entity for invalid form requests.
@@ -19,8 +19,8 @@ RSpec.describe Cops::FormErrorResponse, :config do
 
   it 'does not register an offense when :unprocessable_entity is present' do
     expect_no_offenses(<<~RUBY)
-      if false
-        # redirect_to
+      if @user.save
+        redirect_to users_url, notice: notice_msg('User successfully updated')
       else
         render :new, status: :unprocessable_entity
       end

--- a/spec/cops/form_error_response_spec.rb
+++ b/spec/cops/form_error_response_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe Cops::FormErrorResponse, :config do
         ^^^^^^^^^^^ Use status: :unprocessable_entity for invalid form requests.
       end
     RUBY
+    expect_correction(<<~RUBY)
+      if @user.save
+        redirect_to users_url, notice: notice_msg('User successfully updated')
+      else
+        render :new, status: :unprocessable_entity
+      end
+    RUBY
   end
 
   it 'does not register an offense when :unprocessable_entity is present' do

--- a/spec/cops/no_chrome_tag_spec.rb
+++ b/spec/cops/no_chrome_tag_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'generators/rolemodel/linters/rubocop/templates/lib/cops/no_chrome_tag'
+require 'rubocop'
+require 'rubocop/rspec/support'
+
+RSpec.describe Cops::NoChromeTag, :config do
+  include RuboCop::RSpec::ExpectOffense
+
+  it 'registers an offense when :chrome is present' do
+    expect_offense(<<~RUBY)
+      it 'expects things', :chrome
+                         ^^^^^^^^^ The :chrome tag is only for testing, and should not be checked into the repository.
+    RUBY
+    expect_correction(%(it 'expects things'\n))
+  end
+
+  it 'registers an offense when chrome: true is present' do
+    expect_offense(<<~RUBY)
+      it 'expects things', chrome: true
+                         ^^^^^^^^^^^^^^ The :chrome tag is only for testing, and should not be checked into the repository.
+    RUBY
+    expect_correction(%(it 'expects things'\n))
+  end
+
+  it 'registers an offense when chrome: true is present with other values' do
+    expect_offense(<<~RUBY)
+      it 'expects things', chrome: true, other: false
+                         ^^^^^^^^^^^^^^ The :chrome tag is only for testing, and should not be checked into the repository.
+    RUBY
+    expect_correction(%(it 'expects things', other: false\n))
+  end
+
+  it 'registers an offense when :chrome is present and chrome: true is present' do
+    expect_offense(<<~RUBY)
+      it 'expects things', :chrome, chrome: true
+                                  ^^^^^^^^^^^^^^ The :chrome tag is only for testing, and should not be checked into the repository.
+                         ^^^^^^^^^ The :chrome tag is only for testing, and should not be checked into the repository.
+    RUBY
+    expect_correction(%(it 'expects things'\n))
+  end
+
+  it 'does not register an offense when chrome: is not present' do
+    expect_no_offenses(<<~RUBY)
+      it 'expects things', :js
+    RUBY
+  end
+end

--- a/spec/generators/rolemodel/rubocop_generator_spec.rb
+++ b/spec/generators/rolemodel/rubocop_generator_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+require 'generators/rolemodel/linters/rubocop/rubocop_generator'
+
+RSpec.describe Rolemodel::Linters::RubocopGenerator, type: :generator do
+  destination File.expand_path('tmp/', File.dirname(__FILE__))
+
+  before { run_generator_against_test_app }
+
+  it 'adds the correct helpers' do
+    assert_file '.rubocop.yml'
+    assert_file 'lib/cops/form_error_response.rb'
+    assert_file 'lib/cops/no_chrome_tag.rb'
+  end
+end


### PR DESCRIPTION
## Why?

Looking for :chrome tags in specs is tedious. This will automate highlighting and removing those.

## What Changed

What changed in this PR?

* [x] Add NoChromeTag cop

## Pre-merge checklist

* [x] Update relevant READMEs
* [x] Update version number in `lib/rolemodel_rails/version.rb`
