### PR TITLE
Add Assign Attributes Override to Soft Destroyable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rolemodel_rails (0.18.0)
+    rolemodel_rails (0.19.0)
 
 GEM
   remote: https://rubygems.org/

--- a/example_rails7/Gemfile
+++ b/example_rails7/Gemfile
@@ -54,4 +54,4 @@ group :test do
   gem 'selenium-webdriver'
 end
 
-gem 'rolemodel_rails', '~> 0.18.0', group: :development, path: '..'
+gem 'rolemodel_rails', '~> 0.19.0', group: :development, path: '..'

--- a/example_rails7/Gemfile.lock
+++ b/example_rails7/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rolemodel_rails (0.18.0)
+    rolemodel_rails (0.19.0)
 
 GEM
   remote: https://rubygems.org/
@@ -315,7 +315,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)
-  rolemodel_rails (~> 0.18.0)!
+  rolemodel_rails (~> 0.19.0)!
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/example_rails8/Gemfile
+++ b/example_rails8/Gemfile
@@ -60,4 +60,4 @@ group :test do
   gem 'selenium-webdriver'
 end
 
-gem 'rolemodel_rails', '~> 0.18.0', group: :development, path: '..'
+gem 'rolemodel_rails', '~> 0.19.0', group: :development, path: '..'

--- a/example_rails8/Gemfile.lock
+++ b/example_rails8/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rolemodel_rails (0.18.0)
+    rolemodel_rails (0.19.0)
 
 GEM
   remote: https://rubygems.org/
@@ -372,7 +372,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
-  rolemodel_rails (~> 0.18.0)!
+  rolemodel_rails (~> 0.19.0)!
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable

--- a/lib/generators/rolemodel/soft_destroyable/templates/soft_destroyable.rb
+++ b/lib/generators/rolemodel/soft_destroyable/templates/soft_destroyable.rb
@@ -39,6 +39,11 @@ module SoftDestroyable
     end
   end
 
+  def assign_attributes(attrs)
+    super(attrs[:_soft_destroy].present? ? attrs.slice(:_soft_destroy) : attrs)
+  end
+
+
   def soft_destroyed?
     deleted_at.present?
   end

--- a/lib/generators/rolemodel/soft_destroyable/templates/soft_destroyable.rb
+++ b/lib/generators/rolemodel/soft_destroyable/templates/soft_destroyable.rb
@@ -43,7 +43,6 @@ module SoftDestroyable
     super(attrs[:_soft_destroy].present? ? attrs.slice(:_soft_destroy) : attrs)
   end
 
-
   def soft_destroyed?
     deleted_at.present?
   end

--- a/lib/generators/rolemodel/soft_destroyable/templates/soft_destroyable_behavior.rb
+++ b/lib/generators/rolemodel/soft_destroyable/templates/soft_destroyable_behavior.rb
@@ -41,6 +41,20 @@ RSpec.shared_examples 'a soft destroyable' do |factory_name, **options|
     end
   end
 
+  describe '#assign_attributes' do
+    it 'ignores other attributes when _soft_destroy is present' do
+      destroyable = create_instance
+      destroyable.assign_attributes(updated_at: Time.current, _soft_destroy: '1')
+      expect(destroyable.changes).to_not include(:updated_at)
+    end
+
+    it 'includes all attributes when _soft_destroy is not present' do
+      destroyable = create_instance
+      destroyable.assign_attributes(updated_at: Time.current)
+      expect(destroyable.changes).to include(:updated_at)
+    end
+  end
+
   describe '#soft_destroy!' do
     it 'sets deleted_at' do
       # given

--- a/lib/rolemodel_rails/version.rb
+++ b/lib/rolemodel_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RolemodelRails
-  VERSION = '0.18.0'
+  VERSION = '0.19.0'
 end


### PR DESCRIPTION
## Why?

When updating a soft destroyable record's attributes, it would attempt to save the record when soft destroying it. 
This would become a problem when other attributes, in addition to `_soft_destroy`, were being assigned. If any of those other attributes were invalid, it would fail to soft destroy the record.

This PR fixes that by overriding the `assign_attributes` method, which rails uses under the hood, to ignore all other attributes if `_soft_destroy` is present.

### Example

This is an existing record with a video link attachment. There are validations around the link being real.
WHEN: I edit the link to no longer be valid, then mark the record for soft destruction.
THEN: I attempt to save, but it gives an error saying the record is invalid and cannot be soft destroyed.

https://github.com/user-attachments/assets/24dee7d9-a903-419e-ac22-32798fafbb76

## What Changed

* [x] Override the `assign_attributes` method to ignore other attributes if `_soft_destroy` is passed

## Pre-merge checklist

* ~Update relevant READMEs~
* [x] Update version number in `lib/rolemodel_rails/version.rb`