### PR TITLE
Update devise forms

### DIFF
--- a/lib/generators/rolemodel/saas/devise/devise_generator.rb
+++ b/lib/generators/rolemodel/saas/devise/devise_generator.rb
@@ -152,6 +152,17 @@ module Rolemodel
       def add_devise_mailer_preview
         copy_file 'spec/mailers/previews/devise_mailer_preview.rb'
       end
+
+      def add_login_styles
+        say 'importing login stylesheet', :green
+        copy_file 'app/assets/stylesheets/login.css'
+
+        return unless File.exist?(File.join(destination_root, 'app/assets/stylesheets/application.scss'))
+
+        append_to_file 'app/assets/stylesheets/application.scss', <<~SCSS
+          @import 'login';
+        SCSS
+      end
     end
   end
 end

--- a/lib/generators/rolemodel/saas/devise/templates/app/assets/stylesheets/login.css
+++ b/lib/generators/rolemodel/saas/devise/templates/app/assets/stylesheets/login.css
@@ -1,0 +1,30 @@
+.app__login {
+  margin: calc(2 * var(--op-space-4x-large)) auto auto;
+  padding-inline: var(--op-space-large);
+  width: 100%;
+  max-width: calc(116 * var(--op-size-unit));
+}
+
+/* This could also be its own card variant */
+.card--login {
+  .card__header {
+    display: flex;
+    justify-content: center;
+  }
+
+  .card__header img {
+    width: calc(23 * var(--op-size-unit));
+  }
+
+  .card__body {
+    padding-block: 0;
+  }
+
+  .card__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--op-space-x-small);
+  }
+}

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/confirmations/new.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/confirmations/new.html.slim
@@ -1,10 +1,10 @@
-h2= t(".resend_confirmation_instructions", default: "Resend confirmation instructions")
-= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    br
-    = f.email_field :email, required: true, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email)
-  .actions
-    = f.submit t(".resend_confirmation_instructions", default: "Resend confirmation instructions")
-= render "devise/shared/links"
+.app__login
+  = simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: 'card card--login' }) do |f|
+    .card__header
+      = image_tag '/CHANGEME'
+    .card__body
+      = f.input :email, required: true, autofocus: true, autocomplete: "email", input_html: { value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) }
+    .card__footer
+      = render "devise/shared/links"
+      div
+        = f.submit t(".resend_confirmation_instructions", default: "Resend confirmation instructions"), class: "btn btn--primary"

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/confirmations/new.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/confirmations/new.html.slim
@@ -1,7 +1,7 @@
 .app__login
   = simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: 'card card--login' }) do |f|
     .card__header
-      = image_tag '/CHANGEME'
+      = image_tag asset_path('logo.png') # TODO: Replace with your own logo
     .card__body
       = f.input :email, required: true, autofocus: true, autocomplete: "email", input_html: { value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) }
     .card__footer

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/invitations/edit.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/invitations/edit.html.slim
@@ -10,4 +10,4 @@
     .card__footer
       = render "devise/shared/links"
       div
-        = f.submit t(".devise.invitations.edit.submit_button"), class: "btn btn--primary"
+        = f.submit t("devise.invitations.edit.submit_button"), class: "btn btn--primary"

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/invitations/edit.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/invitations/edit.html.slim
@@ -1,16 +1,13 @@
-h2
-  = t "devise.invitations.edit.header"
-= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  = f.hidden_field :invitation_token, readonly: true
-  - if f.object.class.require_password_on_accepting
-    .field
-      = f.label :password
-      br
-      = f.password_field :password, required: true
-    .field
-      = f.label :password_confirmation
-      br
-      = f.password_field :password_confirmation, required: true
-  .actions
-    = f.submit t("devise.invitations.edit.submit_button")
+.app__login
+  = simple_form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put, class: 'card card--login' }) do |f|
+    = render "devise/shared/error_messages", resource: resource
+    = f.hidden_field :invitation_token, readonly: true
+    .card__header
+      h2 = t "devise.invitations.edit.header"
+    .card__body
+      = f.input :password, label: t(".new_password", default: "New password"), required: true, autofocus: true, autocomplete: "new-password", hint: (@minimum_password_length ? t("devise.shared.minimum_password_length", count: @minimum_password_length, default: "(%{count} characters minimum)") : nil)
+      = f.input :password_confirmation, label: t(".confirm_new_password", default: "Confirm new password"), required: true, autocomplete: "new-password"
+    .card__footer
+      = render "devise/shared/links"
+      div
+        = f.submit t(".devise.invitations.edit.submit_button"), class: "btn btn--primary"

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/invitations/new.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/invitations/new.html.slim
@@ -1,5 +1,5 @@
 .app__login
-  = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'card card--login' }) do |f|
+  = simple_form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { class: 'card card--login' }) do |f|
     .card__header
       h2 = t "devise.invitations.new.header"
     .card__body

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/invitations/new.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/invitations/new.html.slim
@@ -1,21 +1,14 @@
-h2
-  = t "devise.invitations.new.header"
-= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :first_name
-    br
-    = f.text_field :first_name, required: true, autofocus: true, autocomplete: "first_name"
-  .field
-    = f.label :last_name
-    br
-    = f.text_field :last_name, required: true, autocomplete: "last_name"
-  - resource.class.invite_key_fields.each do |field|
-    .field
-      = f.label field
-      br
-      = f.text_field field, required: true
-  - if @organization
-    = f.hidden_field :organization_id, @organization.id
-  .actions
-    = f.submit t("devise.invitations.new.submit_button")
+.app__login
+  = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'card card--login' }) do |f|
+    .card__header
+      h2 = t "devise.invitations.new.header"
+    .card__body
+      = f.input :first_name, required: true, autofocus: true, autocomplete: "first_name"
+      = f.input :last_name, required: true, autocomplete: "last_name"
+      - resource.class.invite_key_fields.each do |field|
+        = f.input field, required: true
+      - if @organization
+        = f.hidden_field :organization_id, @organization.id
+    .card__footer
+      div
+        = f.submit t("devise.invitations.new.submit_button"), class: 'btn btn--primary'

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/passwords/edit.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/passwords/edit.html.slim
@@ -1,7 +1,7 @@
 .app__login
   = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'card card--login' }) do |f|
     .card__header
-      = image_tag '/CHANGEME'
+      = image_tag asset_path('logo.png') # TODO: Replace with your own logo
     .card__body
       = f.hidden_field :reset_password_token
       = f.input :password, label: t(".new_password", default: "New password"), required: true, autofocus: true, autocomplete: "new-password", hint: (@minimum_password_length ? t("devise.shared.minimum_password_length", count: @minimum_password_length, default: "(%{count} characters minimum)") : nil)

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/passwords/edit.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/passwords/edit.html.slim
@@ -1,19 +1,12 @@
-h2= t(".change_your_password", default: "Change your password")
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  = f.hidden_field :reset_password_token
-  .field
-    = f.label :password, t(".new_password", default: "New password")
-    br
-    - if @minimum_password_length
-      em
-        = t("devise.shared.minimum_password_length", count: @minimum_password_length, default: "(%{count} characters minimum)")
-      br
-    = f.password_field :password, required: true, autofocus: true, autocomplete: "new-password"
-  .field
-    = f.label :password_confirmation, t(".confirm_new_password", default: "Confirm new password")
-    br
-    = f.password_field :password_confirmation, required: true, autocomplete: "new-password"
-  .actions
-    = f.submit t(".change_my_password", default: "Change my password")
-= render "devise/shared/links"
+.app__login
+  = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'card card--login' }) do |f|
+    .card__header
+      = image_tag '/CHANGEME'
+    .card__body
+      = f.hidden_field :reset_password_token
+      = f.input :password, label: t(".new_password", default: "New password"), required: true, autofocus: true, autocomplete: "new-password", hint: (@minimum_password_length ? t("devise.shared.minimum_password_length", count: @minimum_password_length, default: "(%{count} characters minimum)") : nil)
+      = f.input :password_confirmation, label: t(".confirm_new_password", default: "Confirm new password"), required: true, autocomplete: "new-password"
+    .card__footer
+      = render "devise/shared/links"
+      div
+        = f.submit t(".change_my_password", default: "Change my password"), class: "btn btn--primary"

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/passwords/new.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/passwords/new.html.slim
@@ -1,7 +1,7 @@
 .app__login
   = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'card card--login' }) do |f|
     .card__header
-      = image_tag '/CHANGEME'
+      = image_tag asset_path('logo.png') # TODO: Replace with your own logo
     .card__body
       = f.input :email, required: true, autofocus: true, autocomplete: "email"
     .card__footer

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/passwords/new.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/passwords/new.html.slim
@@ -1,10 +1,10 @@
-h2= t(".forgot_your_password", default: "Forgot your password?")
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    br
-    = f.email_field :email, required: true, autofocus: true, autocomplete: "email"
-  .actions
-    = f.submit t(".send_me_reset_password_instructions", default: "Send me reset password instructions")
-= render "devise/shared/links"
+.app__login
+  = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'card card--login' }) do |f|
+    .card__header
+      = image_tag '/CHANGEME'
+    .card__body
+      = f.input :email, required: true, autofocus: true, autocomplete: "email"
+    .card__footer
+      = render "devise/shared/links"
+      div
+        = f.submit t(".send_me_reset_password_instructions", default: "Send me reset password instructions"), class: "btn btn--primary"

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/registrations/edit.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/registrations/edit.html.slim
@@ -1,7 +1,7 @@
 .app__login
   = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'card card--login' }) do |f|
     .card__header
-      = image_tag '/CHANGEME'
+      = image_tag asset_path('logo.png') # TODO: Replace with your own logo
     .card__body
       = f.input :first_name, required: true, autofocus: true, autocomplete: "first_name"
       = f.input :last_name, required: true, autocomplete: "last_name"

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/registrations/edit.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/registrations/edit.html.slim
@@ -1,50 +1,33 @@
-h2= t(".title", resource: resource_name.to_s.humanize, default: "Edit %{resource}")
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :first_name
-    br
-    = f.text_field :first_name, required: true, autofocus: true, autocomplete: "first_name"
-  .field
-    = f.label :last_name
-    br
-    = f.text_field :last_name, required: true, autocomplete: "last_name"
-  - if resource.admin? || resource.super_admin?
-    .field
-      = f.label :organization_name
-      br
-      = f.text_field :organization_name, required: resource.organization.users.many?, autocomplete: "organization_name"
-  .field
-    = f.label :email
-    br
-    = f.email_field :email, required: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    div
-      = t(".currently_waiting_confirmation_for_email", email: resource.unconfirmed_email, default: "Currently waiting confirmation for: %{email}")
-  .field
-    = f.label :password
-    i
-      = "(#{t(".leave_blank_if_you_don_t_want_to_change_it", default: "leave blank if you don't want to change it")})"
-    br
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
-      br
-      em
-        = t("devise.shared.minimum_password_length", count: @minimum_password_length, default: "(%{count} characters minimum)")
-  .field
-    = f.label :password_confirmation
-    br
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    i
-      = "(#{t(".we_need_your_current_password_to_confirm_your_changes", default: "we need your current password to confirm your changes")})"
-    br
-    = f.password_field :current_password, required: true, autocomplete: "current-password"
-  .actions
-    = f.submit t(".update", default: "Update")
-h3= t(".cancel_my_account", default: "Cancel my acount")
-p
-  = t(".unhappy", "Unhappy?")
-  = button_to t(".cancel_my_account", default: "Cancel my account"), registration_path(resource_name), data: { confirm: t(".are_you_sure", default: "Are you sure?") }, method: :delete
-= link_to t("devise.shared.links.back", default: "Back"), :back
+.app__login
+  = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'card card--login' }) do |f|
+    .card__header
+      = image_tag '/CHANGEME'
+    .card__body
+      = f.input :first_name, required: true, autofocus: true, autocomplete: "first_name"
+      = f.input :last_name, required: true, autocomplete: "last_name"
+      - if resource.admin? || resource.super_admin?
+        = f.input :organization_name, required: resource.organization.users.many?, autocomplete: "organization_name"
+      = f.input :email, required: true, autocomplete: "email"
+      - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+        p.text-sm.text-gray-600
+          = t(".currently_waiting_confirmation_for_email", email: resource.unconfirmed_email, default: "Currently waiting confirmation for: %{email}")
+      = f.input :password, autocomplete: "new-password", hint: t(".leave_blank_if_you_don_t_want_to_change_it", default: "leave blank if you don't want to change it"), required: false
+      = f.input :password_confirmation, autocomplete: "new-password", required: false
+      = f.input :current_password, hint: t(".we_need_your_current_password_to_confirm_your_changes", default: "we need your current password to confirm your changes"), required: true, autocomplete: "current-password"
+    .card__footer
+      div
+        = f.submit t(".update", default: "Update"), class: "btn btn--primary"
+
+.app__login.margin-top-md
+  .card.card--login
+    .card__header
+      h3= t(".cancel_my_account", default: "Cancel my account")
+    .card__body
+      p
+        = t(".unhappy", default: "Unhappy?")
+    .card__footer
+      div
+        = button_to t(".cancel_my_account", default: "Cancel my account"), registration_path(resource_name), data: { confirm: t(".are_you_sure", default: "Are you sure?") }, method: :delete, class: "btn btn--danger"
+
+.margin-top-md.text-center
+  = link_to t("devise.shared.links.back", default: "Back"), :back, class: "btn btn--secondary"

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/registrations/new.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/registrations/new.html.slim
@@ -1,7 +1,7 @@
 .app__login
   = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'card card--login' }) do |f|
     .card__header
-      = image_tag '/CHANGEME'
+      = image_tag asset_path('logo.png') # TODO: Replace with your own logo
     .card__body
       = f.input :first_name, required: true, autofocus: true
       = f.input :last_name, required: true

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/registrations/new.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/registrations/new.html.slim
@@ -1,7 +1,8 @@
-.flex.flex-col.items-center
-  h2.margin-top-lg= t(".sign_up", default: "Sign up")
-  .card.container--xs.margin-top-md
-    = simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+.app__login
+  = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'card card--login' }) do |f|
+    .card__header
+      = image_tag '/CHANGEME'
+    .card__body
       = f.input :first_name, required: true, autofocus: true
       = f.input :last_name, required: true
       = f.simple_fields_for :organization do |organization_field|
@@ -9,7 +10,7 @@
       = f.input :email, required: true, autocomplete: "email"
       = f.input :password, required: true, autocomplete: "new-password"
       = f.input :password_confirmation, required: true, autocomplete: "new-password"
-      .actions
-        = f.submit t(".sign_up", default: "Sign up"), class: 'btn btn--primary'
-    .margin-top-md
+    .card__footer
       = render "devise/shared/links"
+      div
+        = f.submit t(".sign_up", default: "Sign up"), class: 'btn btn--primary'

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/sessions/new.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/sessions/new.html.slim
@@ -1,12 +1,13 @@
-.flex.flex-col.items-center
-  h2.margin-top-lg= t(".sign_in", default: "Log in")
-  .card.container--xs.margin-top-md
-    = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+.app__login
+  = simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'card card--login' }) do |f|
+    .card__header
+      = image_tag '/CHANGEME'
+    .card__body
       = f.input :email, required: true, autofocus: true, autocomplete: "email"
       = f.input :password, required: true, autocomplete: "current-password"
       - if devise_mapping.rememberable?
         = f.input :remember_me, as: :boolean
-      .actions
-        = f.submit t(".sign_in", default: "Log in"), class: "btn btn--primary"
-    .margin-top-md
+    .card__footer
       = render "devise/shared/links"
+      div
+        = f.submit t(".sign_in", default: "Log in"), class: "btn btn--primary"

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/sessions/new.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/sessions/new.html.slim
@@ -1,7 +1,7 @@
 .app__login
   = simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'card card--login' }) do |f|
     .card__header
-      = image_tag '/CHANGEME'
+      = image_tag asset_path('logo.png') # TODO: Replace with your own logo
     .card__body
       = f.input :email, required: true, autofocus: true, autocomplete: "email"
       = f.input :password, required: true, autocomplete: "current-password"

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/shared/_error_messages.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/shared/_error_messages.html.slim
@@ -1,10 +1,9 @@
 - if resource.errors.any?
-  #error_explanation
-    h2
+  .alert.alert--danger.margin-bottom-md
+    h4.margin-bottom-xs
       = I18n.t("errors.messages.not_saved",
         count: resource.errors.count,
         resource: resource.class.model_name.human.downcase)
-    ul
+    ul.list.list--unstyled
       - resource.errors.full_messages.each do |message|
-        li
-          = message
+        li= message

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/shared/_links.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/shared/_links.html.slim
@@ -1,19 +1,14 @@
-- if controller_name != "sessions"
-  = link_to t(".sign_in", default: "Log in"), new_session_path(resource_name)
-  br
-- if devise_mapping.registerable? && controller_name != "registrations"
-  = link_to t(".sign_up", default: "Sign up"), new_registration_path(resource_name)
-  br
-- if devise_mapping.recoverable? && controller_name != "passwords" && controller_name != "registrations"
-  = link_to t(".forgot_your_password", default: "Forgot your password?"), new_password_path(resource_name)
-  br
-- if devise_mapping.confirmable? && controller_name != "confirmations"
-  = link_to t(".didn_t_receive_confirmation_instructions", default: "Didn't receive confirmation instructions?"), new_confirmation_path(resource_name)
-  br
-- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != "unlocks"
-  = link_to t(".didn_t_receive_unlock_instructions", default: "Didn't receive unlock instructions?"), new_unlock_path(resource_name)
-  br
-- if devise_mapping.omniauthable?
-  - resource_class.omniauth_providers.each do |provider|
-    = link_to t(".sign_in_with_provider", provider: OmniAuth::Utils.camelize(provider), default: "Sign in with %{provider}"), omniauth_authorize_path(resource_name, provider)
-    br
+.flex.flex-col.gap-xs
+  - if controller_name != "sessions"
+    = link_to t(".sign_in", default: "Log in"), new_session_path(resource_name)
+  - if devise_mapping.registerable? && controller_name != "registrations"
+    = link_to t(".sign_up", default: "Sign up"), new_registration_path(resource_name)
+  - if devise_mapping.recoverable? && controller_name != "passwords" && controller_name != "registrations"
+    = link_to t(".forgot_your_password", default: "Forgot your password?"), new_password_path(resource_name)
+  - if devise_mapping.confirmable? && controller_name != "confirmations"
+    = link_to t(".didn_t_receive_confirmation_instructions", default: "Didn't receive confirmation instructions?"), new_confirmation_path(resource_name)
+  - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != "unlocks"
+    = link_to t(".didn_t_receive_unlock_instructions", default: "Didn't receive unlock instructions?"), new_unlock_path(resource_name)
+  - if devise_mapping.omniauthable?
+    - resource_class.omniauth_providers.each do |provider|
+      = link_to t(".sign_in_with_provider", provider: OmniAuth::Utils.camelize(provider), default: "Sign in with %{provider}"), omniauth_authorize_path(resource_name, provider)

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/unlocks/new.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/unlocks/new.html.slim
@@ -1,10 +1,10 @@
-h2= t(".resend_unlock_instructions", default: "Resend unlock instructions")
-= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    br
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .actions
-    = f.submit t(".resend_unlock_instructions", default: "Resend unlock instructions")
-= render "devise/shared/links"
+.app__login
+  = simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post, class: 'card card--login' }) do |f|
+    .card__header
+      = image_tag '/CHANGEME'
+    .card__body
+      = f.input :email, autofocus: true, autocomplete: "email"
+    .card__footer
+      = render "devise/shared/links"
+      div
+        = f.submit t(".resend_unlock_instructions", default: "Resend unlock instructions"), class: "btn btn--primary"

--- a/lib/generators/rolemodel/saas/devise/templates/app/views/devise/unlocks/new.html.slim
+++ b/lib/generators/rolemodel/saas/devise/templates/app/views/devise/unlocks/new.html.slim
@@ -1,7 +1,7 @@
 .app__login
   = simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post, class: 'card card--login' }) do |f|
     .card__header
-      = image_tag '/CHANGEME'
+      = image_tag asset_path('logo.png') # TODO: Replace with your own logo
     .card__body
       = f.input :email, autofocus: true, autocomplete: "email"
     .card__footer

--- a/lib/generators/rolemodel/testing/rspec/templates/spec_helper.rb
+++ b/lib/generators/rolemodel/testing/rspec/templates/spec_helper.rb
@@ -59,7 +59,7 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = 'spec/examples.txt'
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
@@ -75,7 +75,7 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
+    config.default_formatter = 'doc'
   end
 
   # Print the 10 slowest examples and example groups at the


### PR DESCRIPTION
## Why?

The Devise forms always look terrible and need customizing. Optics docs already have a recommended pattern for login forms: https://docs.optics.rolemodel.design/?path=/docs/recipes-layout--docs&globals=theme:dark

## What Changed

What changed in this PR?

* [X] Add Optics to the Devise forms

## Pre-merge checklist

* [x] Update relevant READMEs
* [x] Update version number in `lib/rolemodel_rails/version.rb`

## Screenshots

<img width="1668" height="2558" alt="image" src="https://github.com/user-attachments/assets/b1e0c0c9-373f-4c95-9754-949ed30ca8ce" />
<img width="994" height="776" alt="image" src="https://github.com/user-attachments/assets/1e8148b5-3ae4-405e-a1c2-f66b37c31a7c" />
<img width="1000" height="933" alt="image" src="https://github.com/user-attachments/assets/d134eb05-6dd7-4ed4-859d-e573fd38c57f" />
<img width="1003" height="875" alt="image" src="https://github.com/user-attachments/assets/9b75bcf6-a969-4892-9ee8-2b41d26b674e" />


