### PR TITLE
Add Parallel Tests Generator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rolemodel_rails (0.16.0)
+    rolemodel_rails (0.17.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ bin/rails g
   * [RSpec](./lib/generators/rolemodel/testing/rspec)
   * [Factory Bot](./lib/generators/rolemodel/testing/factory_bot)
   * [Test Prof](./lib/generators/rolemodel/testing/test_prof)
+  * [Parallel Test](./lib/generators/rolemodel/testing/parallel_tests)
 * [SimpleForm](./lib/generators/rolemodel/simple_form)
 * [SoftDestroyable](./lib/generators/rolemodel/soft_destroyable)
 * [SaaS](./lib/generators/rolemodel/saas)

--- a/lib/generators/rolemodel/testing/README.md
+++ b/lib/generators/rolemodel/testing/README.md
@@ -7,3 +7,4 @@
 * [RSpec](./rspec)
 * [FactoryBot](./factory_bot)
 * [TestProf](./test_prof)
+* [ParallelTests](./parallel_tests)

--- a/lib/generators/rolemodel/testing/parallel_tests/README.md
+++ b/lib/generators/rolemodel/testing/parallel_tests/README.md
@@ -1,0 +1,42 @@
+# Parallel Tests Generator
+
+## What you get
+
+### Parallel Tests Setup
+
+This generator configures your Rails application to run RSpec tests in parallel, greatly reducing the time it takes to run your test suite.
+
+### Gemfile Addition
+
+The generator will add the `parallel_tests` gem to your Gemfile and run bundle install.
+
+```rb
+group :development, :test do
+  gem 'parallel_tests'
+end
+```
+
+### Database Configuration
+
+Your `database.yml` will be updated to support parallel test databases. This allows each test process to use its own isolated database.
+
+```yaml
+test:
+  # ...existing configuration...
+  database: your_app_test<%= ENV['TEST_ENV_NUMBER'] %>
+```
+
+### Running Parallel Tests
+
+Once configured, you can run your tests in parallel using:
+
+```bash
+# Run entire test suite in parallel
+bundle exec rake parallel:spec
+
+# Run specific tests in parallel
+bundle exec rake parallel:spec[spec/models]
+
+# Specify number of processes (default is the number of CPUs)
+bundle exec rake parallel:spec[spec,4]
+```

--- a/lib/generators/rolemodel/testing/parallel_tests/USAGE
+++ b/lib/generators/rolemodel/testing/parallel_tests/USAGE
@@ -1,0 +1,9 @@
+Description:
+    generates configuration for running RSpec tests in parallel
+
+Example:
+    rails generate rolemodel:testing:parallel_rspec
+
+    This will add:
+        parallel_tests to your Gemfile
+        database.yml configuration for parallel testing

--- a/lib/generators/rolemodel/testing/parallel_tests/parallel_tests_generator.rb
+++ b/lib/generators/rolemodel/testing/parallel_tests/parallel_tests_generator.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative '../../../bundler_helpers'
+
+module Rolemodel
+  module Testing
+    class ParallelTestsGenerator < Rails::Generators::Base # rubocop:disable Style/Documentation
+      include Rolemodel::BundlerHelpers
+      source_root File.expand_path('templates', __dir__)
+
+      def install_parallel_tests
+        gem_group :development, :test do
+          gem 'parallel_tests'
+        end
+        run_bundle
+      end
+
+      def configure_database_for_parallel_testing
+        say_status :update, 'Updating database.yml for parallel testing', :blue
+
+        database_config = File.read('config/database.yml')
+        app_name = database_config.match(/database:.(.*)_test/)[1]
+        new_database_config = "database: #{app_name}_test<%= ENV['TEST_ENV_NUMBER'] %>"
+
+        gsub_file 'config/database.yml', /database:.*_test/, new_database_config
+        say_status :update, 'Updated database configuration successfully', :green
+      end
+
+      def setup_parallel_test_databases
+        say_status :setup, 'Setting up parallel test databases...', :blue
+        run 'bundle exec rake parallel:setup'
+      end
+
+      def display_post_install_message
+        say_status :info, 'Parallel Tests has been configured!', :green
+        say_status :info, 'You can now run your tests in parallel with:', :green
+        say_status :info, 'bundle exec rake parallel:spec', :green
+      end
+    end
+  end
+end

--- a/lib/rolemodel_rails/version.rb
+++ b/lib/rolemodel_rails/version.rb
@@ -1,3 +1,3 @@
 module RolemodelRails
-  VERSION = '0.16.0'.freeze
+  VERSION = '0.17.0'.freeze
 end

--- a/spec/generators/rolemodel/parallel_test_generator_spec.rb
+++ b/spec/generators/rolemodel/parallel_test_generator_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'generators/rolemodel/testing/parallel_tests/parallel_tests_generator'
+
+RSpec.describe Rolemodel::Testing::ParallelTestsGenerator, type: :generator do
+  destination File.expand_path('tmp/', File.dirname(__FILE__))
+
+  before { run_generator_against_test_app }
+
+  it 'adds the gem and edits the database.yml' do
+    assert_file 'Gemfile' do |content|
+      expect(content).to include('gem "parallel_tests"')
+    end
+
+    assert_file 'config/database.yml' do |content|
+      expect(content.scan(/database:.*_test/).size).to eq(1) # Ensure old test database name is removed
+      expect(content).to match(/database:.*_test<%= ENV\['TEST_ENV_NUMBER'\] %>/)
+    end
+  end
+end


### PR DESCRIPTION
## Why?

There requires some slight configuration for parallel tests to be added and cooperate with Rails apps. This PR adds a generator to make that even easier.

## What Changed

* [x] Add Parallel Tests generator to add the gem, update the `database.yml`, and run `rake parallel:setup`

## Pre-merge checklist

* [x] Update relevant READMEs
* [x] Update version number in `lib/rolemodel_rails/version.rb`