### PR TITLE
Add rspec_parallel and Turbo Tests to Parallel RSpec Generator

### DIFF
--- a/lib/generators/rolemodel/testing/parallel_tests/README.md
+++ b/lib/generators/rolemodel/testing/parallel_tests/README.md
@@ -8,12 +8,22 @@ This generator configures your Rails application to run RSpec tests in parallel,
 
 ### Gemfile Addition
 
-The generator will add the `parallel_tests` gem to your Gemfile and run bundle install.
+The generator will add the `parallel_tests` and `turbo_tests` gems to your Gemfile and run bundle install.
 
 ```rb
 group :development, :test do
   gem 'parallel_tests'
+  gem 'turbo_tests'
 end
+```
+
+### RSpec Configuration
+The generator will create a `.rspec_parallel` file in your Rails root directory.
+
+```
+--format RspecJunitFormatter --out tmp/rspec-<%= ENV['TEST_ENV_NUMBER'] %>.xml
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/turbo_rspec_runtime.log
+--format ParallelTests::RSpec::FailuresLogger
 ```
 
 ### Database Configuration

--- a/lib/generators/rolemodel/testing/parallel_tests/README.md
+++ b/lib/generators/rolemodel/testing/parallel_tests/README.md
@@ -8,7 +8,7 @@ This generator configures your Rails application to run RSpec tests in parallel,
 
 ### Gemfile Addition
 
-The generator will add the `parallel_tests` and `turbo_tests` gems to your Gemfile and run bundle install.
+The generator will add the `parallel_tests`, `turbo_tests`, and `rspec_junit_formatter` gems to your Gemfile and run bundle install.
 
 ```rb
 group :development, :test do

--- a/lib/generators/rolemodel/testing/parallel_tests/README.md
+++ b/lib/generators/rolemodel/testing/parallel_tests/README.md
@@ -13,7 +13,8 @@ The generator will add the `parallel_tests` and `turbo_tests` gems to your Gemfi
 ```rb
 group :development, :test do
   gem 'parallel_tests'
-  gem 'turbo_tests'
+  gem 'turbo_tests', require: false
+  gem 'rspec_junit_formatter', require: false
 end
 ```
 

--- a/lib/generators/rolemodel/testing/parallel_tests/USAGE
+++ b/lib/generators/rolemodel/testing/parallel_tests/USAGE
@@ -6,4 +6,6 @@ Example:
 
     This will add:
         parallel_tests to your Gemfile
+        turbo_tests to your Gemfile for a nicer testing experience
+        .rspec_parallel file for RSpec configuration
         database.yml configuration for parallel testing

--- a/lib/generators/rolemodel/testing/parallel_tests/USAGE
+++ b/lib/generators/rolemodel/testing/parallel_tests/USAGE
@@ -7,5 +7,6 @@ Example:
     This will add:
         parallel_tests to your Gemfile
         turbo_tests to your Gemfile for a nicer testing experience
+        rspec_junit_formatter for test reporting
         .rspec_parallel file for RSpec configuration
         database.yml configuration for parallel testing

--- a/lib/generators/rolemodel/testing/parallel_tests/parallel_tests_generator.rb
+++ b/lib/generators/rolemodel/testing/parallel_tests/parallel_tests_generator.rb
@@ -11,7 +11,8 @@ module Rolemodel
       def install_parallel_tests
         gem_group :development, :test do
           gem 'parallel_tests'
-          gem 'turbo_tests'
+          gem 'turbo_tests', require: false
+          gem 'rspec_junit_formatter', require: false
         end
         run_bundle
       end

--- a/lib/generators/rolemodel/testing/parallel_tests/parallel_tests_generator.rb
+++ b/lib/generators/rolemodel/testing/parallel_tests/parallel_tests_generator.rb
@@ -15,6 +15,10 @@ module Rolemodel
         run_bundle
       end
 
+      def add_rspec_parallel_file
+        template '.rspec_parallel', '.rspec_parallel'
+      end
+
       def configure_database_for_parallel_testing
         say_status :update, 'Updating database.yml for parallel testing', :blue
 

--- a/lib/generators/rolemodel/testing/parallel_tests/parallel_tests_generator.rb
+++ b/lib/generators/rolemodel/testing/parallel_tests/parallel_tests_generator.rb
@@ -11,6 +11,7 @@ module Rolemodel
       def install_parallel_tests
         gem_group :development, :test do
           gem 'parallel_tests'
+          gem 'turbo_tests'
         end
         run_bundle
       end

--- a/lib/generators/rolemodel/testing/parallel_tests/templates/.rspec_parallel
+++ b/lib/generators/rolemodel/testing/parallel_tests/templates/.rspec_parallel
@@ -1,0 +1,3 @@
+--format RspecJunitFormatter --out tmp/rspec-<%= ENV['TEST_ENV_NUMBER'] %>.xml
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/turbo_rspec_runtime.log
+--format ParallelTests::RSpec::FailuresLogger

--- a/spec/generators/rolemodel/parallel_test_generator_spec.rb
+++ b/spec/generators/rolemodel/parallel_test_generator_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Rolemodel::Testing::ParallelTestsGenerator, type: :generator do
   it 'adds the gem, adds .rspec_parallel, and edits the database.yml' do
     assert_file 'Gemfile' do |content|
       expect(content).to include('gem "parallel_tests"')
+      expect(content).to include('gem "turbo_tests"')
     end
 
     assert_file '.rspec_parallel'

--- a/spec/generators/rolemodel/parallel_test_generator_spec.rb
+++ b/spec/generators/rolemodel/parallel_test_generator_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe Rolemodel::Testing::ParallelTestsGenerator, type: :generator do
 
   before { run_generator_against_test_app }
 
-  it 'adds the gem and edits the database.yml' do
+  it 'adds the gem, adds .rspec_parallel, and edits the database.yml' do
     assert_file 'Gemfile' do |content|
       expect(content).to include('gem "parallel_tests"')
     end
+
+    assert_file '.rspec_parallel'
 
     assert_file 'config/database.yml' do |content|
       expect(content.scan(/database:.*_test/).size).to eq(1) # Ensure old test database name is removed

--- a/spec/generators/rolemodel/parallel_test_generator_spec.rb
+++ b/spec/generators/rolemodel/parallel_test_generator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Rolemodel::Testing::ParallelTestsGenerator, type: :generator do
 
   before { run_generator_against_test_app }
 
-  it 'adds the gem, adds .rspec_parallel, and edits the database.yml' do
+  it 'adds the gems, adds .rspec_parallel, and edits the database.yml' do
     assert_file 'Gemfile' do |content|
       expect(content).to include('gem "parallel_tests"')
       expect(content).to include('gem "turbo_tests"')

--- a/spec/generators/rolemodel/parallel_test_generator_spec.rb
+++ b/spec/generators/rolemodel/parallel_test_generator_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Rolemodel::Testing::ParallelTestsGenerator, type: :generator do
   it 'adds the gems, adds .rspec_parallel, and edits the database.yml' do
     assert_file 'Gemfile' do |content|
       expect(content).to include('gem "parallel_tests"')
-      expect(content).to include('gem "turbo_tests"')
+      expect(content).to include('gem "turbo_tests", require: false')
+      expect(content).to include('gem "rspec_junit_formatter", require: false')
     end
 
     assert_file '.rspec_parallel'


### PR DESCRIPTION
## Why?

I realized I forgot to add the `.rspec_parallel` file to the generator. I also wanted to add the `turbo_test` gem for optional use.

## What Changed

* [x] Add `.rspec_parallel` file
* [x] Add `turbo_test` gem
* [x] Add `rspec_junit_formatter` gem

## Pre-merge checklist

* [x] Update relevant READMEs
* ~[ ] Update version number in `lib/rolemodel_rails/version.rb`~