### PR TITLE
Add Release Workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,10 @@ What changed in this PR?
 ## Pre-merge checklist
 
 * [ ] Update relevant READMEs
-* [ ] Run `bin/bump_version` or `bin/bump_version --patch`
+
+## Notes
+
+Please don't commit version changes within your PR.  Versioning is managed through the Github Workflow.
 
 ## Screenshots
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ What changed in this PR?
 
 ## Notes
 
-Please don't commit version changes within your PR.  Versioning is managed through the Github Workflow.
+Please don't commit version changes within your PR.  Versioning is managed through the GitHub Workflow.
 
 ## Screenshots
 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -3,14 +3,13 @@ name: Bump Version & Publish a Github Release
 on:
   workflow_dispatch:
     inputs:
-      version_bump:
-        description: SemVer Bump Type
-        required: true
+      bump-type:
+        description: SemVer Bump Type (minor by default)
+        required: false
         type: choice
         options:
-          - patch
-          - minor
-          - major
+          - --patch
+          - --major
 
 permissions:
   contents: write
@@ -18,11 +17,6 @@ permissions:
 jobs:
   push:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      id-token: write
-
     steps:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
@@ -32,21 +26,7 @@ jobs:
         id: bump_version
         run: |
           set -euo pipefail
-
-          case "${{ github.event.inputs.version_bump }}" in
-            patch)
-              bin/bump_version --patch
-              ;;
-            minor)
-              bin/bump_version
-              ;;
-            major)
-              bin/bump_version --major
-              ;;
-          esac
-
-          # The bump script builds a gem into pkg/; keep repo history source-only.
-          rm -f pkg/*.gem
+          bin/bump_version ${{ github.event.inputs.bump-type }}
 
           version="$(ruby -e "require './lib/rolemodel/version'; puts Rolemodel::VERSION")"
           tag_name="v${version}"
@@ -54,18 +34,9 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-          git add lib/rolemodel/version.rb Gemfile.lock example_rails_legacy/Gemfile.lock
+          git add .
           git commit -m "${tag_name}"
-          git tag "${tag_name}"
 
           git push origin "HEAD:${GITHUB_REF_NAME}"
-          git push origin "${tag_name}"
 
           echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
-
-      - name: Create GitHub release
-        run: |
-          tag_name='${{ steps.bump_version.outputs.tag_name }}'
-          gh release create "${tag_name}" --generate-notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,71 @@
+name: Bump Version & Publish a Github Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: SemVer Bump Type
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with: { bundler-cache: true }
+
+      - name: Bump, commit, and tag version
+        id: bump_version
+        run: |
+          set -euo pipefail
+
+          case "${{ github.event.inputs.version_bump }}" in
+            patch)
+              bin/bump_version --patch
+              ;;
+            minor)
+              bin/bump_version
+              ;;
+            major)
+              bin/bump_version --major
+              ;;
+          esac
+
+          # The bump script builds a gem into pkg/; keep repo history source-only.
+          rm -f pkg/*.gem
+
+          version="$(ruby -e "require './lib/rolemodel/version'; puts Rolemodel::VERSION")"
+          tag_name="v${version}"
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          git add lib/rolemodel/version.rb Gemfile.lock example_rails_legacy/Gemfile.lock
+          git commit -m "${tag_name}"
+          git tag "${tag_name}"
+
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push origin "${tag_name}"
+
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        run: |
+          tag_name='${{ steps.bump_version.outputs.tag_name }}'
+          gh release create "${tag_name}" --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,4 +1,4 @@
-name: Bump Version & Publish a Github Release
+name: Bump Version & Publish a GitHub Release
 
 on:
   workflow_dispatch:
@@ -26,7 +26,7 @@ jobs:
         id: bump_version
         run: |
           set -euo pipefail
-          bin/bump_version ${{ github.event.inputs.bump-type }}
+          bin/bump_version ${{ github.event.inputs['bump-type'] }}
 
           version="$(ruby -e "require './lib/rolemodel/version'; puts Rolemodel::VERSION")"
           tag_name="v${version}"
@@ -36,7 +36,6 @@ jobs:
 
           git add .
           git commit -m "${tag_name}"
+          git tag "${tag_name}"
 
-          git push origin "HEAD:${GITHUB_REF_NAME}"
-
-          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+          git push origin "HEAD:${GITHUB_REF_NAME}" --follow-tags

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -4,11 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       bump-type:
-        description: SemVer Bump Type (minor by default)
+        description: SemVer Bump Type
         required: false
+        default: --minor
         type: choice
         options:
           - --patch
+          - --minor
           - --major
 
 permissions:
@@ -33,5 +35,5 @@ jobs:
 
       - name: Bump, commit, tag, and push version
         env:
-          BUMP_VERSION_AUTOMATED: 'true'
+          BUMP_VERSION_AUTOMATED: "true"
         run: bin/bump_version ${{ github.event.inputs['bump-type'] }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -14,28 +14,24 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   push:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with: { bundler-cache: true }
 
-      - name: Bump, commit, and tag version
-        id: bump_version
+      - name: Configure git identity
         run: |
-          set -euo pipefail
-          bin/bump_version ${{ github.event.inputs['bump-type'] }}
-
-          version="$(ruby -e "require './lib/rolemodel/version'; puts Rolemodel::VERSION")"
-          tag_name="v${version}"
-
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-          git add .
-          git commit -m "${tag_name}"
-          git tag "${tag_name}"
-
-          git push origin "HEAD:${GITHUB_REF_NAME}" --follow-tags
+      - name: Bump, commit, tag, and push version
+        env:
+          BUMP_VERSION_AUTOMATED: 'true'
+        run: bin/bump_version ${{ github.event.inputs['bump-type'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   run_specs:
     name: Rspec
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       CI: true

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,20 @@
+name: Publish New Gem Version to RubyGems.org
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with: { persist-credentials: false }
+      - uses: ruby/setup-ruby@v1
+        with: { bundler-cache: true }
+      - uses: rubygems/release-gem@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
       - name: Create GitHub release
         run: |
           tag_name="$(git describe --tags --abbrev=0)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,26 @@
-name: Publish gem to rubygems.org
+name: Create GitHub Release & Publish gem to rubygems.org
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
-  contents: read
+  contents: write
+  id-token: write
 
 jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub release
+        run: |
+          tag_name="$(git describe --tags --abbrev=0)"
+          gh release create "${tag_name}" --verify-tag --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   push:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      id-token: write
-
     steps:
       - uses: actions/checkout@v6
         with: { persist-credentials: false }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Publish gem to rubygems.org
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with: { persist-credentials: false }
+      - uses: ruby/setup-ruby@v1
+        with: { bundler-cache: true }
+      - uses: rubygems/release-gem@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,17 @@
-name: Create GitHub Release & Publish gem to rubygems.org
+name: Create GitHub Release
 
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Create GitHub release
@@ -20,11 +20,3 @@ jobs:
           gh release create "${tag_name}" --verify-tag --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  push:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with: { persist-credentials: false }
-      - uses: ruby/setup-ruby@v1
-        with: { bundler-cache: true }
-      - uses: rubygems/release-gem@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,14 +234,23 @@ GEM
       rubocop-ast (>= 1.45.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.45.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
-      prism (~> 1.4)
-    rubocop-rails (2.29.1)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+    rubocop-rails (2.36.0)
       activesupport (>= 4.2.0)
+      lint_roller (~> 1.1)
       rack (>= 1.1)
-      rubocop (>= 1.52.0, < 2.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
+    rubocop-rails-omakase (1.1.0)
+      rubocop (>= 1.72)
+      rubocop-performance (>= 1.24)
+      rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     stimulus-rails (1.3.4)
@@ -285,6 +294,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop
   rubocop-rails
+  rubocop-rails-omakase
   stimulus-rails
   turbo-rails
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/bump_version
+++ b/bin/bump_version
@@ -24,10 +24,6 @@ class VersionBumper < Thor::Group
     run_clean_bundle_install
   end
 
-  def build_gem
-    run 'gem build rolemodel-rails.gemspec'
-  end
-
   def update_current_example_app
     Rake::FileList.new('example_rails_*').each do |example_path|
       inside(example_path) do

--- a/bin/bump_version
+++ b/bin/bump_version
@@ -16,6 +16,15 @@ class VersionBumper < Thor::Group
 
   source_root File.expand_path('../', __FILE__)
 
+  def verify_automated_environment
+    return if ENV['BUMP_VERSION_AUTOMATED'] == 'true'
+
+    raise Thor::InvocationError, <<~MSG.strip
+      This process is automated via the "Bump Version & Publish a GitHub Release" GitHub Actions workflow.
+      Trigger it from the Actions tab instead of running bin/bump_version locally.
+    MSG
+  end
+
   def bump_version
     gsub_file 'lib/rolemodel/version.rb', /^  VERSION = .*/, "  VERSION = '#{new_version_string}'"
   end
@@ -30,6 +39,23 @@ class VersionBumper < Thor::Group
         run_clean_bundle_install
       end
     end
+  end
+
+  def commit_and_tag_version
+    run 'git add .', abort_on_failure: true
+    run "git commit -m #{tag_name}", abort_on_failure: true
+    # -m makes this an annotated tag; `git push --follow-tags` only pushes annotated
+    # tags, so a lightweight `git tag #{tag_name}` would silently never reach origin.
+    run "git tag -m #{tag_name} #{tag_name}", abort_on_failure: true
+  end
+
+  def push_version_and_tag
+    # --atomic is required here: without it, a rejected (non-fast-forward) branch
+    # update wouldn't stop the new tag from landing anyway, since new tag refs
+    # aren't subject to the fast-forward check -- that would publish a tag (and
+    # trigger a real RubyGems release) built from a commit that never reached
+    # the branch it was supposed to land on.
+    run "git push --atomic origin \"HEAD:#{ENV.fetch('GITHUB_REF_NAME')}\" --follow-tags", abort_on_failure: true
   end
 
   def echo_new_version
@@ -57,6 +83,10 @@ class VersionBumper < Thor::Group
     )
   end
 
+  def tag_name
+    "v#{new_version_string}"
+  end
+
   def run_clean_bundle_install
     Bundler.with_original_env do
       run "#{Gem.bin_path("bundler", "bundle")} install --quiet"
@@ -64,9 +94,10 @@ class VersionBumper < Thor::Group
   end
 
   class << self
+    def exit_on_failure? = true
     def banner = 'bin/bump_version [--patch|--major|--version VERSION]'
     def desc = 'Update Gem Version & Sync Example Apps'
   end
 end
 
-VersionBumper.start(ARGV)
+VersionBumper.start(ARGV) if __FILE__ == $PROGRAM_NAME

--- a/bin/bump_version
+++ b/bin/bump_version
@@ -11,7 +11,8 @@ class VersionBumper < Thor::Group
   class_exclusive do
     class_option :patch, type: :boolean, lazy_default: false, desc: 'Bump patch version instead of minor version'
     class_option :major, type: :boolean, lazy_default: false, desc: 'Bump major version instead of minor version'
-    class_option :version, type: :string, desc: 'Bump to a specific version (overrides patch and major options)'
+    class_option :minor, type: :boolean, lazy_default: true, desc: 'Bump minor version (default behavior)'
+    class_option :version, type: :string, desc: 'Bump to a specific version (overrides all other flags)'
   end
 
   source_root File.expand_path('../', __FILE__)
@@ -19,6 +20,7 @@ class VersionBumper < Thor::Group
   def verify_automated_environment
     return if ENV['BUMP_VERSION_AUTOMATED'] == 'true'
 
+    say 'Not so fast, cowboy!', :red
     raise Thor::InvocationError, <<~MSG.strip
       This process is automated via the "Bump Version & Publish a GitHub Release" GitHub Actions workflow.
       Trigger it from the Actions tab instead of running bin/bump_version locally.

--- a/rolemodel-rails.gemspec
+++ b/rolemodel-rails.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rails'
+  spec.add_development_dependency 'rubocop-rails-omakase'
   spec.add_development_dependency 'benchmark'
 end

--- a/spec/bin/bump_version_spec.rb
+++ b/spec/bin/bump_version_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+load File.expand_path('../../bin/bump_version', __dir__)
+
+RSpec.describe VersionBumper do
+  after do
+    ENV.delete('BUMP_VERSION_AUTOMATED')
+  end
+
+  describe 'automated-environment guard' do
+    it 'raises before bumping anything when BUMP_VERSION_AUTOMATED is not set' do
+      ENV.delete('BUMP_VERSION_AUTOMATED')
+
+      expect { described_class.new([], {}).invoke_all }.to raise_error(Thor::InvocationError, /GitHub Actions workflow/)
+    end
+
+    it 'raises when BUMP_VERSION_AUTOMATED is set to a non-true value' do
+      ENV['BUMP_VERSION_AUTOMATED'] = 'false'
+
+      expect { described_class.new([], {}).invoke_all }.to raise_error(Thor::InvocationError)
+    end
+  end
+
+  describe 'process exit status' do
+    it 'exits non-zero with the guard message, and leaves the version file untouched' do
+      env = ENV.to_h.merge('BUMP_VERSION_AUTOMATED' => nil)
+      version_before = File.read('lib/rolemodel/version.rb')
+
+      _stdout, stderr, status = Open3.capture3(env, RbConfig.ruby, File.expand_path('../../bin/bump_version', __dir__))
+
+      expect(status).not_to be_success
+      expect(stderr).to include('GitHub Actions workflow')
+      expect(File.read('lib/rolemodel/version.rb')).to eq(version_before)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Version bumps no longer require a manual commit inside every PR. Triggering a workflow now bumps the version, commits, tags, and pushes automatically, and a tag push produces a GitHub Release with generated notes, which in turn publishes the gem to [RubyGems.org](<http://RubyGems.org>) -- three single-purpose workflows instead of one that tried to do everything inline.

## What changed

* `bin/bump_version` **now owns the full git sequence** (add, commit, annotated tag, push) instead of `bump_version.yml` doing it inline in shell. The tag has to point at the version-bump commit, and the only way to guarantee that ordering is to let the same process create both.
* **A** `BUMP_VERSION_AUTOMATED` **guard** blocks the script from running outside the workflow, so a local `bin/bump_version` invocation can't accidentally commit, tag, or push to `master`. This required overriding Thor::Group's `exit_on_failure?` -- it defaults to `false`, so without the override the guard's error would print but the process would still exit `0`.
* `release.yml` **no longer also publishes the gem.** That duplicated the newly-added `publish-package.yml`, which now owns the RubyGems publish on `release: published`. `release.yml` only creates the GitHub Release.
* **The push is atomic.** Code review caught a real bug here: without `--atomic`, a rejected (non-fast-forward) branch update wouldn't stop the new tag from landing anyway, since new tag refs aren't subject to the fast-forward check. That would silently publish a tag -- and trigger a real RubyGems release -- built from a commit that never actually reached `master`. Reproduced the exact cascade in an isolated scratch repo, confirmed `--atomic` closes it.

```mermaid
flowchart TB
  A[workflow_dispatch: bump_version.yml] --> B[bin/bump_version: bump, commit, tag, atomic push]
  B --> C[Tag push triggers release.yml]
  C --> D[GitHub Release created w/ generated notes]
  D --> E[release: published triggers publish-package.yml]
  E --> F[rubygems/release-gem: gem pushed to RubyGems.org]
```

## Testing

* Full `rspec` suite green (88 examples).
* New `spec/bin/bump_version_spec.rb` covers the guard clause: raises without the automation flag, raises on a falsy value, and exits non-zero as a subprocess with the guard message and no file changes.
* `rubocop` clean on touched files (6 pre-existing offenses remain, none introduced by this change).
* Manually verified end-to-end in disposable scratch git repos (not this repo): the full bump -> commit -> tag -> push sequence lands correctly, and separately, that `--atomic` actually blocks the tag from landing when the branch push is rejected.

## Known Residuals

Code review (9 reviewer personas) surfaced three items accepted as-is rather than fixed in this PR:

* `workflow_dispatch` on `bump_version.yml` has no branch/ref restriction -- any collaborator with write access could trigger a bump from a non-`master` branch. Accepted scope boundary.
* `publish-package.yml` triggers on any `release: published` event with no tag-pattern check -- a manually-created GitHub Release would also trigger a real RubyGems publish. This is the trigger this PR was asked to implement; flagging in case a tag-pattern guard is wanted later.
* `bump_version.yml`'s `bump-type` choice input has no explicit `default:`, so "minor by default" may not be what the GitHub UI actually submits when left untouched. Pre-existing YAML that predates this rework.

## Post-Deploy Monitoring & Validation

* **Watch:** the Actions logs for "Bump Version & Publish a GitHub Release", "Create GitHub Release", and "Publish New Gem Version to [RubyGems.org](<http://RubyGems.org>)".
* **Healthy:** `workflow_dispatch` completes green; a `vX.Y.Z` tag and matching commit land on `master`; a GitHub Release appears with generated notes; the new gem version appears on [rubygems.org](<http://rubygems.org>).
* **If it fails:** `bump_version.yml` failing leaves no partial tag/branch state on origin (that's what `--atomic` guarantees) -- safe to just re-trigger. `release.yml` failing after a tag landed can be recovered with `gh release create <tag> --generate-notes`. `publish-package.yml` failing (e.g. RubyGems trusted publishing not yet configured) leaves the GitHub Release published but the gem unpublished -- configure trusted publishing, then re-run the failed job; the underlying `rake release` task detects the tag already exists and skips re-tagging.
* **Window:** the first real release run through this pipeline after merge.

---

## Screenshots

<img src="https://github.com/user-attachments/assets/1317a208-7d07-400a-bb5d-dfb77439b09c " alt="Main (-zsh) — \~CODERoleModelrolemodel_rails 07 16 2026@092637 @2x" width="1834" data-linear-height="792" />

---

[![Compound Engineering](https://uploads.linear.app/0179a878-40c1-433c-85ad-ed1d8e97b7e6/307a3ff4-9038-439f-b0a9-98eec3b2451e/78060dc8-56ca-47ce-a2d1-089bf2ea783b?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzAxNzlhODc4LTQwYzEtNDMzYy04NWFkLWVkMWQ4ZTk3YjdlNi8zMDdhM2ZmNC05MDM4LTQzOWYtYjBhOS05OGVlYzNiMjQ1MWUvNzgwNjBkYzgtNTZjYS00N2NlLWEyZDEtMDg5YmYyZWE3ODNiIiwiaWF0IjoxNzg0MjI2MTk3LCJleHAiOjE4MTU3OTY3NTd9.sPVGC9X-sNHkMRUU0DZEQHrFB4WHJy7n9vcOp0ZDA98)](<https://github.com/EveryInc/compound-engineering-plugin>)

![Claude Code](https://camo.githubusercontent.com/64f53917b035e6acbf17910810d1f7afdeb8df9f576db8e75548a7003941849b/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f536f6e6e65745f352d4439373735373f6c6f676f3d636c61756465266c6f676f436f6c6f723d7768697465)