### PR TITLE
Move IconBuilders into The engine

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rolemodel-rails (1.1.0)
+    rolemodel-rails (1.2.0)
       rails (> 7.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    rolemodel-rails (1.2.0)
+    rolemodel-rails (2.0.0)
+      benchmark
       rails (> 7.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -28,12 +28,15 @@ rails db:create
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'rolemodel-rails', group: :development
+gem 'rolemodel-rails'
 ```
+
+> [!IMPORTANT]
+> We used to recommend putting rolemodel-rails in the development gem group. This is no longer supported, because some Rolemodel namespaced utility modules and classes are expected to be available at runtime.
 
 And then execute:
 
-    $ bundle
+    $ bundle install
 
 ## Usage
 
@@ -115,10 +118,6 @@ bin/new_generator testing/fantasitic_specs 'A Fantastic Testing Framework'
 
 We use the embeded Rails apps (`example_rails_current` & `example_rails_legacy`) to test generators against. They reference the rolemodel-rails gem by local path,
 so you can navigate into one of them and run your generator for immediate feedback while developing.
-
-> [!IMPORTANT]
-> Before submitting a PR, run `bin/bump_version` to ensure the Gem builds successfully & that everything continues to stay in sync & up-to-date.<br /><br />
-> For very small changes & bug fixes, prefer `bin/bump_version --patch`.
 
 ## Testing
 

--- a/example_rails_legacy/Gemfile.lock
+++ b/example_rails_legacy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rolemodel-rails (1.1.0)
+    rolemodel-rails (1.2.0)
       rails (> 7.1)
 
 GEM

--- a/example_rails_legacy/Gemfile.lock
+++ b/example_rails_legacy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rolemodel-rails (1.2.0)
+    rolemodel-rails (2.0.0)
       rails (> 7.1)
 
 GEM

--- a/lib/generators/rolemodel/optics/icons/README.md
+++ b/lib/generators/rolemodel/optics/icons/README.md
@@ -5,3 +5,8 @@
 ## What you get
 
 Adds icon helper for handling icon generation using the provider of your choice.
+
+## Icon Builder Customization
+
+Run the generator with the `-i` option to install the IconBuilders themselves in your
+application's `lib/rolemodel/optics` directory.

--- a/lib/generators/rolemodel/optics/icons/README.md
+++ b/lib/generators/rolemodel/optics/icons/README.md
@@ -4,4 +4,4 @@
 
 ## What you get
 
-Adds icon helper for handling material icons and custom icons
+Adds icon helper for handling icon generation using the provider of your choice.

--- a/lib/generators/rolemodel/optics/icons/icons_generator.rb
+++ b/lib/generators/rolemodel/optics/icons/icons_generator.rb
@@ -4,6 +4,7 @@ module Rolemodel
   module Optics
     # Generates the icon helper and icon builders for the chosen icon library
     class IconsGenerator < Rolemodel::GeneratorBase
+      BUILDER_DIR = 'rolemodel/optics'
       SUPPORTED_LIBRARIES = HashWithIndifferentAccess.new(
         material: 'filled, size, weight, emphasis, additional_classes, color, hover_text',
         phosphor: 'duotone, filled, size, weight, additional_classes, color, hover_text',
@@ -14,6 +15,9 @@ module Rolemodel
       ).freeze
 
       source_root File.expand_path('templates', __dir__)
+      class_option :install_builders, aliases: '-i', type: :boolean, default: false,
+                   desc: "Install IconBuilder classes for customization"
+
       class_exclusive do
         SUPPORTED_LIBRARIES.keys.each do |library|
           class_option library, type: :boolean, lazy_default: false, desc: "Use #{library} icon library"
@@ -27,10 +31,18 @@ module Rolemodel
         template 'app/helpers/icon_helper.rb', force: true
       end
 
+      def install_builders
+        return unless options.install_builders?
+
+        source_paths << File.expand_path(BUILDER_DIR, Rolemodel::GEM_LIB)
+        copy_file 'icon_builder.rb', "lib/#{BUILDER_DIR}/icon_builder.rb", force: true
+        copy_file "#{@chosen_library}_icon_builder.rb", "lib/#{BUILDER_DIR}/#{@chosen_library}_icon_builder.rb", force: true
+      end
+
     private
 
       def capture_user_selection
-        options.except(*%i[skip_namespace skip_collision_check]).invert[true] || ask(
+        options.slice(*SUPPORTED_LIBRARIES.keys).invert[true] || ask(
           'What icon library would you like to add?',
           default: SUPPORTED_LIBRARIES.keys.first.to_s,
           limited_to: SUPPORTED_LIBRARIES.keys.map(&:to_s)

--- a/lib/generators/rolemodel/optics/icons/icons_generator.rb
+++ b/lib/generators/rolemodel/optics/icons/icons_generator.rb
@@ -20,18 +20,11 @@ module Rolemodel
         end
       end
 
-      def remove_existing_icon_helper_and_builders
-        remove_dir 'app/icon_builders'
-        remove_file 'app/helpers/icon_helper.rb'
-      end
-
       def add_view_helper
         @chosen_library = capture_user_selection
         @supported_properties = SUPPORTED_LIBRARIES.fetch(@chosen_library)
 
-        template 'app/icon_builders/icon_builder.rb'
-        template "app/icon_builders/#{@chosen_library}_icon_builder.rb"
-        template 'app/helpers/icon_helper.rb'
+        template 'app/helpers/icon_helper.rb', force: true
       end
 
     private

--- a/lib/generators/rolemodel/optics/icons/templates/app/helpers/icon_helper.rb.tt
+++ b/lib/generators/rolemodel/optics/icons/templates/app/helpers/icon_helper.rb.tt
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rolemodel/optics'
+
 # Helper method that renders icons from your icon library of choice.
 #
 # Usage:
@@ -14,11 +16,11 @@
 module IconHelper
   # <%= @supported_properties %>
   def icon(name, **)
-    <%= @chosen_library.classify %>IconBuilder.new(name, **).build
+    Rolemodel::Optics::<%= @chosen_library.classify %>IconBuilder.new(name, **).build
   end
 
   # <%= @supported_properties %>
   def flash_icon(type, **)
-    <%= @chosen_library.classify %>IconBuilder.flash_icon(type, **).build
+    Rolemodel::Optics::<%= @chosen_library.classify %>IconBuilder.flash_icon(type, **).build
   end
 end

--- a/lib/rolemodel-rails.rb
+++ b/lib/rolemodel-rails.rb
@@ -3,6 +3,8 @@
 module Rolemodel
   NODE_VERSION = '24.12.0'
   RUBY_VERSION = '4.0.1'
+
+  GEM_LIB = File.expand_path(__dir__)
 end
 
 require 'rolemodel/version'

--- a/lib/rolemodel/engine.rb
+++ b/lib/rolemodel/engine.rb
@@ -4,6 +4,8 @@ module Rolemodel
   class Engine < ::Rails::Engine
     require_relative 'generator_base'
 
+    paths.add 'rolemodel/optics', eager_load: true
+
     generators do
       require 'generators/rolemodel/all_generator'
     end

--- a/lib/rolemodel/engine.rb
+++ b/lib/rolemodel/engine.rb
@@ -4,8 +4,6 @@ module Rolemodel
   class Engine < ::Rails::Engine
     require_relative 'generator_base'
 
-    paths.add 'rolemodel/optics', eager_load: true
-
     generators do
       require 'generators/rolemodel/all_generator'
     end

--- a/lib/rolemodel/optics.rb
+++ b/lib/rolemodel/optics.rb
@@ -1,0 +1,9 @@
+module Rolemodel::Optics
+  autoload :IconBuilder, 'rolemodel/optics/icon_builder'
+  autoload :CustomIconBuilder, 'rolemodel/optics/custom_icon_builder'
+  autoload :FeatherIconBuilder, 'rolemodel/optics/feather_icon_builder'
+  autoload :LucideIconBuilder, 'rolemodel/optics/lucide_icon_builder'
+  autoload :MaterialIconBuilder, 'rolemodel/optics/material_icon_builder'
+  autoload :PhosphorIconBuilder, 'rolemodel/optics/phosphor_icon_builder'
+  autoload :TablerIconBuilder, 'rolemodel/optics/tabler_icon_builder'
+end

--- a/lib/rolemodel/optics/custom_icon_builder.rb
+++ b/lib/rolemodel/optics/custom_icon_builder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # CustomIconBuilder is an IconBuilder that allows for custom SVG icons to be used in the application.
-class CustomIconBuilder < IconBuilder
+class Rolemodel::Optics::CustomIconBuilder < Rolemodel::Optics::IconBuilder
   def self.flash_icons
     {
       notice: 'circle-check',

--- a/lib/rolemodel/optics/feather_icon_builder.rb
+++ b/lib/rolemodel/optics/feather_icon_builder.rb
@@ -2,7 +2,7 @@
 
 # FeatherIconBuilder is an IconBuilder that allows for Feather icons to be used in the application.
 # https://feathericons.com/
-class FeatherIconBuilder < IconBuilder
+class Rolemodel::Optics::FeatherIconBuilder < Rolemodel::Optics::IconBuilder
   def self.flash_icons
     {
       notice: 'check-circle',

--- a/lib/rolemodel/optics/icon_builder.rb
+++ b/lib/rolemodel/optics/icon_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class IconBuilder
+class Rolemodel::Optics::IconBuilder
   include ActionView::Helpers::TagHelper
 
   attr_reader :name, :filled, :size, :weight, :emphasis, :duotone, :additional_classes, :color, :hover_text

--- a/lib/rolemodel/optics/lucide_icon_builder.rb
+++ b/lib/rolemodel/optics/lucide_icon_builder.rb
@@ -2,7 +2,7 @@
 
 # LucideIconBuilder is an IconBuilder that allows for Lucide icons to be used in the application.
 # https://lucide.dev/icons/
-class LucideIconBuilder < IconBuilder
+class Rolemodel::Optics::LucideIconBuilder < Rolemodel::Optics::IconBuilder
   def self.flash_icons
     {
       notice: 'circle-check',

--- a/lib/rolemodel/optics/material_icon_builder.rb
+++ b/lib/rolemodel/optics/material_icon_builder.rb
@@ -2,7 +2,7 @@
 
 # MaterialIconBuilder is an IconBuilder that allows for Material icons to be used in the application.
 # https://fonts.google.com/icons
-class MaterialIconBuilder < IconBuilder
+class Rolemodel::Optics::MaterialIconBuilder < Rolemodel::Optics::IconBuilder
   def self.flash_icons
     {
       notice: 'check_circle',

--- a/lib/rolemodel/optics/phosphor_icon_builder.rb
+++ b/lib/rolemodel/optics/phosphor_icon_builder.rb
@@ -2,7 +2,7 @@
 
 # PhosphorIconBuilder is an IconBuilder that allows for Phosphor icons to be used in the application.
 # https://phosphoricons.com/
-class PhosphorIconBuilder < IconBuilder
+class Rolemodel::Optics::PhosphorIconBuilder < Rolemodel::Optics::IconBuilder
   def self.flash_icons
     {
       notice: 'check-circle',

--- a/lib/rolemodel/optics/tabler_icon_builder.rb
+++ b/lib/rolemodel/optics/tabler_icon_builder.rb
@@ -2,7 +2,7 @@
 
 # TablerIconBuilder is an IconBuilder that allows for Tabler icons to be used in the application.
 # https://tablericons.com/
-class TablerIconBuilder < IconBuilder
+class Rolemodel::Optics::TablerIconBuilder < Rolemodel::Optics::IconBuilder
   def self.flash_icons
     {
       notice: 'circle-check',

--- a/lib/rolemodel/utility.rb
+++ b/lib/rolemodel/utility.rb
@@ -1,0 +1,3 @@
+module Rolemodel::Utility
+  autoload :TaskTools, 'rolemodel/utility/task_tools'
+end

--- a/lib/rolemodel/utility/task_tools.rb
+++ b/lib/rolemodel/utility/task_tools.rb
@@ -1,0 +1,48 @@
+require 'benchmark'
+
+module Rolemodel
+  module Utility
+    module TaskTools
+      PROGRESS = %w[⠏ ⠇ ⠧ ⠦ ⠴ ⠼ ⠸ ⠹ ⠙ ⠋].to_enum
+
+      # based on the migration helper of the same name
+      def say_with_time(message, &)
+        say message
+        time = Benchmark.measure(&)
+        say '%.4fs' % time.real, :subitem
+      end
+
+      def say(message, subitem = false) # rubocop:disable Style/OptionalBooleanParameter
+        puts "#{subitem ? '   ->' : '--'} #{message}" # rubocop:disable Rails/Output
+      end
+
+      ##
+      # Indicate the progress of a long-running process
+      #
+      # Usage (with a known total):
+      # 100.times do |i|
+      #   indicate_progress(i, 100)
+      # end
+      #
+      # Only update every 'report_interval' iteration for eye-trackable animation speed
+      # Also displays a completion percentage if a total is provided
+      def indicate_progress(index, total = nil, report_interval: 9)
+        return unless (index % report_interval).zero?
+
+        print("#{indicator} #{to_percent(index, total) if total}\r") # rubocop:disable Rails/Output
+      end
+
+      private
+
+      def indicator
+        PROGRESS.next
+      rescue StopIteration
+        PROGRESS.rewind.next
+      end
+
+      def to_percent(index, total)
+        '%3.f%%' % (index / total.to_f * 100.0)
+      end
+    end
+  end
+end

--- a/lib/rolemodel/version.rb
+++ b/lib/rolemodel/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rolemodel
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/lib/rolemodel/version.rb
+++ b/lib/rolemodel/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rolemodel
-  VERSION = '1.2.0'
+  VERSION = '2.0.0'
 end

--- a/rolemodel-rails.gemspec
+++ b/rolemodel-rails.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rails', '> 7.1'
+  spec.add_dependency 'benchmark'
 
   spec.add_development_dependency 'bundler', '~> 4'
   spec.add_development_dependency 'generator_spec', '~> 0.10'

--- a/spec/generators/rolemodel/optics/icons_generator_spec.rb
+++ b/spec/generators/rolemodel/optics/icons_generator_spec.rb
@@ -57,4 +57,24 @@ RSpec.describe Rolemodel::Optics::IconsGenerator, type: :generator do
       end
     end
   end
+
+  context 'installing builders' do
+    before do
+      run_generator_against_test_app(['--phosphor', '--install-builders'])
+    end
+
+    it 'copies the base IconBuilder and the chosen library builder to the app lib directory' do
+      assert_file 'lib/rolemodel/optics/icon_builder.rb'
+      assert_file 'lib/rolemodel/optics/phosphor_icon_builder.rb'
+    end
+  end
+
+  context 'not installing builders (default)' do
+    before { run_generator_against_test_app(['--phosphor']) }
+
+    it 'does not copy any builder files to the app lib directory' do
+      assert_no_file 'lib/rolemodel/optics/icon_builder.rb'
+      assert_no_file 'lib/rolemodel/optics/phosphor_icon_builder.rb'
+    end
+  end
 end

--- a/spec/generators/rolemodel/optics/icons_generator_spec.rb
+++ b/spec/generators/rolemodel/optics/icons_generator_spec.rb
@@ -5,20 +5,36 @@ RSpec.describe Rolemodel::Optics::IconsGenerator, type: :generator do
       run_generator_against_test_app
     end
 
-    it 'adds the correct helper and builders' do
-      assert_file 'app/helpers/icon_helper.rb'
-      assert_file 'app/icon_builders/icon_builder.rb'
-      assert_file 'app/icon_builders/material_icon_builder.rb'
+    it 'adds the correct helper' do
+      assert_file 'app/helpers/icon_helper.rb' do |helper|
+        assert_instance_method :icon, helper
+        assert_match(/MaterialIconBuilder/, helper)
+      end
     end
   end
 
   context 'selecting an alternate icon library via command line option' do
     before { run_generator_against_test_app(['--phosphor']) }
 
-    it 'adds the correct helper and builders' do
-      assert_file 'app/helpers/icon_helper.rb'
-      assert_file 'app/icon_builders/icon_builder.rb'
-      assert_file 'app/icon_builders/phosphor_icon_builder.rb'
+    it 'adds the correct helper' do
+      assert_file 'app/helpers/icon_helper.rb' do |helper|
+        assert_instance_method :icon, helper
+        assert_match(/PhosphorIconBuilder/, helper)
+      end
+    end
+  end
+
+  context 'selecting an alternate icon library via prompt' do
+    before do
+      respond_to_prompt with: 'feather' # choose an icon library
+      run_generator_against_test_app
+    end
+
+    it 'adds the correct helper' do
+      assert_file 'app/helpers/icon_helper.rb' do |helper|
+        assert_instance_method :icon, helper
+        assert_match(/FeatherIconBuilder/, helper)
+      end
     end
   end
 
@@ -27,16 +43,18 @@ RSpec.describe Rolemodel::Optics::IconsGenerator, type: :generator do
       assert_no_file 'app/helpers/icon_helper.rb'
 
       run_generator_against_test_app(['--tabler'])
-      assert_file 'app/helpers/icon_helper.rb'
-      assert_file 'app/icon_builders/tabler_icon_builder.rb'
+      assert_file 'app/helpers/icon_helper.rb' do |helper|
+        assert_instance_method :icon, helper
+        assert_match(/TablerIconBuilder/, helper)
+        assert_no_match(/PhosphorIconBuilder/, helper)
+      end
 
-      respond_to_prompt with: 'feather' # choose an icon library
-      run_generator_against_test_app
-      assert_file 'app/helpers/icon_helper.rb'
-      assert_file 'app/icon_builders/feather_icon_builder.rb'
-
-      assert_no_file 'app/icon_builders/tabler_icon_builder.rb'
-      assert_no_file 'app/icon_builders/material_icon_builder.rb'
+      run_generator_against_test_app(['--lucide'])
+      assert_file 'app/helpers/icon_helper.rb' do |helper|
+        assert_instance_method :icon, helper
+        assert_match(/LucideIconBuilder/, helper)
+        assert_no_match(/TablerIconBuilder/, helper)
+      end
     end
   end
 end


### PR DESCRIPTION
## Why?

Adding a top level directory for 'app/icon_builders' for a peripheral concept like a view helper is not ideal.  And while the helper itself is very much application specific, maintaining the icon builders themselves doesn't need to be the responsibility of the consuming application.

## What Changed

What changed in this PR?

- [x] Move icon builders to lib/rolemodel/optics
- [x] Add `--install-builders` (`-i`) option
- [x] Skip builder install unless `options.install_builders?`
- [x] Add documentation & additional specs

## Pre-merge checklist

* [x] Update relevant READMEs
* [x] Run `bin/bump_version` or `bin/bump_version --patch`

## Screenshots

<img width="932" height="592" alt="Main (-zsh) — ~CODERoleModelrolemodel_railsexample_rails_current 04 29 2026@114313" src="https://github.com/user-attachments/assets/2b394c64-a3aa-4cf4-8cce-307d575749a3" />


<img width="460" height="132" alt="Main (-zsh) — ~CODERoleModelrolemodel_railsexample_rails_current 04 29 2026@114925" src="https://github.com/user-attachments/assets/0550f634-b353-41b2-9cd0-9e8d5201f6d4" />

<img width="1204" height="503" alt="icon_builder rb — example_rails_current 04 29 2026@115116" src="https://github.com/user-attachments/assets/56059d14-bc17-44f7-9036-33650b630f35" />

<img width="581" height="128" alt="Main (ruby) — ~CODERoleModelrolemodel_railsexample_rails_current 04 29 2026@115151" src="https://github.com/user-attachments/assets/ccb83194-a941-4f38-82a6-b4a503357581" />
